### PR TITLE
Un-export rotate, scale, translate

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ImagePhantoms"
 uuid = "71a99df6-f52c-4da1-bd2a-69d6f37f3252"
 authors = ["Jeff Fessler <fessler@umich.edu> and contributors"]
-version = "0.0.1"
+version = "0.0.2"
 
 [deps]
 SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"

--- a/src/object.jl
+++ b/src/object.jl
@@ -7,7 +7,7 @@ ellipses, rectangles, and gaussian bumps.
 
 export AbstractObject
 export Object, Object2d, Object3d
-export rotate, scale, translate
+#export rotate, scale, translate # no: to avoid conflicts with Plots
 export phantom, radon, spectrum
 
 atuple(x::Any, n::Int) = ntuple(i -> x, n)
@@ -27,11 +27,10 @@ General container for 2D and 3D objects for defining image phantoms.
 * `value::V` "intensity" value for this object
 * `param` optional additional shape parameters (often `nothing`)
 
-Example
+# Example
 
 ```jldoctest
 julia> Object(Ellipse(), (0,0), (1,2), 0.0, 1//2, nothing)
-
 Object2d{Ellipse, Rational{Int64}, 2, Int64, Float64, Nothing} (S, D, V, ...)
  shape::Ellipse Ellipse()
  center::Tuple{Int64, Int64} (0, 0)

--- a/test/ellipse.jl
+++ b/test/ellipse.jl
@@ -4,6 +4,7 @@ ellipse.jl
 
 using ImagePhantoms #: Object2d, AbstractShape2
 using ImagePhantoms #: Ellipse, Circle
+import ImagePhantoms as IP
 using Unitful: m, unit
 #using MIRTjim: jim, prompt
 #using UnitfulRecipes
@@ -43,17 +44,17 @@ end
 
     ob = @inferred shape((1,2.), (3,4//1), π, 5.0f0)
 
-    @isob @NOTinferred rotate(ob, π)
+    @isob @NOTinferred IP.rotate(ob, π)
 
-    @test rotate(ob, -ob.angle[1]).angle[1] == 0
+    @test IP.rotate(ob, -ob.angle[1]).angle[1] == 0
 
     @isob @inferred ob * 2//1
     @isob @inferred 2 * ob
     @isob @inferred ob / 2.0f0
-    @isob @inferred scale(ob, (2,3))
-    @isob @inferred scale(ob, 2)
-    @isob @inferred translate(ob, (2, 3))
-    @isob @inferred translate(ob, 2, 3)
+    @isob @inferred IP.scale(ob, (2,3))
+    @isob @inferred IP.scale(ob, 2)
+    @isob @inferred IP.translate(ob, (2, 3))
+    @isob @inferred IP.translate(ob, 2, 3)
 end
 
 

--- a/test/gauss2.jl
+++ b/test/gauss2.jl
@@ -4,6 +4,7 @@ gauss2.jl
 
 using ImagePhantoms #: Object2d, AbstractShape2
 using ImagePhantoms #: Gauss2
+import ImagePhantoms as IP
 using Unitful: m, unit, °
 #using MIRTjim: jim, prompt
 #using UnitfulRecipes
@@ -38,17 +39,17 @@ end
 
     ob = @inferred shape((1,2.), (3,4//1), π, 5.0f0)
 
-    @isob @NOTinferred rotate(ob, π)
+    @isob @NOTinferred IP.rotate(ob, π)
 
-    @test rotate(ob, -ob.angle[1]).angle[1] == 0
+    @test IP.rotate(ob, -ob.angle[1]).angle[1] == 0
 
     @isob @inferred ob * 2//1
     @isob @inferred 2 * ob
     @isob @inferred ob / 2.0f0
-    @isob @inferred scale(ob, (2,3))
-    @isob @inferred scale(ob, 2)
-    @isob @inferred translate(ob, (2, 3))
-    @isob @inferred translate(ob, 2, 3)
+    @isob @inferred IP.scale(ob, (2,3))
+    @isob @inferred IP.scale(ob, 2)
+    @isob @inferred IP.translate(ob, (2, 3))
+    @isob @inferred IP.translate(ob, 2, 3)
 end
 
 

--- a/test/rect.jl
+++ b/test/rect.jl
@@ -4,6 +4,7 @@ rect.jl
 
 using ImagePhantoms #: Object2d, AbstractShape2
 using ImagePhantoms #: Rect, Square
+import ImagePhantoms as IP
 using Unitful: m, unit
 #using MIRTjim: jim, prompt
 #using UnitfulRecipes
@@ -43,17 +44,17 @@ end
 
     ob = @inferred shape((1,2.), (3,4//1), π, 5.0f0)
 
-    @isob @NOTinferred rotate(ob, π)
+    @isob @NOTinferred IP.rotate(ob, π)
 
-    @test rotate(ob, -ob.angle[1]).angle[1] == 0
+    @test IP.rotate(ob, -ob.angle[1]).angle[1] == 0
 
     @isob @inferred ob * 2//1
     @isob @inferred 2 * ob
     @isob @inferred ob / 2.0f0
-    @isob @inferred scale(ob, (2,3))
-    @isob @inferred scale(ob, 2)
-    @isob @inferred translate(ob, (2, 3))
-    @isob @inferred translate(ob, 2, 3)
+    @isob @inferred IP.scale(ob, (2,3))
+    @isob @inferred IP.scale(ob, 2)
+    @isob @inferred IP.translate(ob, (2, 3))
+    @isob @inferred IP.translate(ob, 2, 3)
 end
 
 


### PR DESCRIPTION
No longer export `rotate, scale, translate` because they conflict with Plots and are not very useful anyway.