### PR TITLE
Remove `param` support at the `Object` level

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ImagePhantoms"
 uuid = "71a99df6-f52c-4da1-bd2a-69d6f37f3252"
 authors = ["Jeff Fessler <fessler@umich.edu> and contributors"]
-version = "0.0.10"
+version = "0.1.0"
 
 [deps]
 LazyGrids = "7031d0ef-c40d-4431-b2f8-61a8d2f650db"

--- a/README.md
+++ b/README.md
@@ -72,6 +72,18 @@ gif(anim, "disk.gif", fps = 8)
 ![animated phantom gif](https://github.com/JuliaImageRecon/ImagePhantoms.jl/blob/gh-pages/dev/generated/examples/disk.gif)
 
 
+### Philosophy
+
+Often "phantoms" are treated as digital images.
+Here, the shapes (rectangles, gaussians, ellipses, etc.)
+are all defined *analytically*
+as functions,
+as are their line integrals
+and Fourier transforms.
+Then one can sample those analytical functions
+to make digital images, sinograms, and spectra.
+
+
 ### Parallel MRI (SENSE)
 
 Most of the methods here are of general use

--- a/docs/lit/examples/30-3d.jl
+++ b/docs/lit/examples/30-3d.jl
@@ -68,7 +68,7 @@ is a collection of (2D) plane integrals,
 whereas the
 [X-ray transform](https://en.wikipedia.org/wiki/X-ray_transform)
 is a collection of (1D) line integrals.
-See 
+See
 [Section II.1, Natterer 2001](http://doi.org/10.1137/1.9780898719284).
 So strictly speaking the `radon` function is a misnomer in 3D,
 whereas for 2D functions

--- a/src/object2.jl
+++ b/src/object2.jl
@@ -14,7 +14,7 @@ export phantom, radon, spectrum
 Rotate a 2D object.
 """
 rotate(ob::Object2d{S}, θ::RealU) where S =
-    Object(S(), ob.center, ob.width, ob.angle .+ (θ,), ob.value, ob.param)
+    Object(S(), ob.center, ob.width, ob.angle .+ (θ,), ob.value)
 
 
 """

--- a/src/object3.jl
+++ b/src/object3.jl
@@ -15,7 +15,7 @@ export phantom, radon, spectrum
 Rotate a 3D object.
 """
 rotate(ob::Object3d{S}, θ::NTuple{2,RealU}) where S =
-    Object(S(), ob.center, ob.width, ob.angle .+ θ, ob.value, ob.param)
+    Object(S(), ob.center, ob.width, ob.angle .+ θ, ob.value)
 rotate(ob::Object3d, α::RealU, β::RealU=0) = rotate(ob, (α,β))
 
 

--- a/src/triangle.jl
+++ b/src/triangle.jl
@@ -22,18 +22,20 @@ going from (-p,0) to (1-p,0)` and with height=sqrt(3)/2.
 
 The methods currently support only the default case `p=0.5`.
 """
-struct Triangle <: AbstractShape{2} end
-
-#=
-struct Triangle{T} <: AbstractShape{2}
-    param::T # fraction in interval (0,1) 
-    function Triangle{T}(param::T = 0.5) where {T <: Real}
+#struct Triangle <: AbstractShape{2} end
+#struct Triangle{T} <: AbstractShape{2}
+struct Triangle <: AbstractShape{2}
+#   param::T # fraction in interval (0,1)
+#   function Triangle{T}(param::T = 0.5) where {T <: Real}
+    function Triangle(param::T = 0.5) where {T <: Real}
         0 < param < 1 || throw(ArgumentError("param=$param"))
-        new{T}(param)
+        param == 0.5 || throw("Need param = 0.5")
+#       new{T}(param)
+        new()
     end
 end
-Triangle(param::T = 0.5) where {T <: Real} = Triangle{T}(param)
-=#
+#Triangle(param::T = 0.5) where {T <: Real} = Triangle{T}(param)
+Triangle(param::T = 0.5) where {T <: Real} = Triangle(param)
 
 
 # constructors
@@ -48,16 +50,14 @@ In the typical case where `param=0.5` and `width[1] == width[2]`,
 this is an equilateral triangle with base `width[1]` centered along the x axis.
 """
 function triangle(args... ; param::Real = 0.5, kwargs...)
-    0 < param < 1 || throw("Need param ∈ (0,1)")
-#   param == 0.5 || throw("Need param = 0.5")
-    return Object(Triangle(), args...; param, kwargs...)
+    return Object(Triangle(param), args...; kwargs...)
 end
 
 
 # helper
 
 function _trifun(x, y, param)
-    param == 1/2 || throw("todo")
+#   param == 1/2 || throw("todo") # no need to check because constructor is 1/2
     return (0 ≤ y ≤ sqrt3/2) && y ≤ sqrt3 * (0.5 - abs(x))
 end
 
@@ -130,13 +130,15 @@ end
 Evaluate unit triangle at `(x,y)`,
 for unitless coordinates.
 """
-phantom1(ob::Object2d{Triangle}, xy::NTuple{2,Real}) = _trifun(xy..., ob.param)
+phantom1(ob::Object2d{Triangle}, xy::NTuple{2,Real}) =
+    _trifun(xy..., 0.5)
+#   _trifun(xy..., ob.param)
 
 
 # x-ray transform (line integral) of unit triangle
 # `r` should be unitless
 function xray1(::Triangle, r::Real, ϕ::RealU)
-    # todo: check ob.param == 1/2
+    # valid only for param == 1/2, but that's ok now because constructor is 1/2
     T = promote_type(eltype(r), Float32)
     return abs(r) ≥ sqrt(3)/2 ? zero(T) : T(radon_tri(r, sincos(ϕ)...))
 end
@@ -148,6 +150,6 @@ Spectrum of unit triangle at `(kx,ky)`,
 for unitless spatial frequency coordinates.
 """
 function spectrum1(ob::Object2d{Triangle}, kxy::NTuple{2,Real})
-    ob.param == 1/2 || throw("todo")
+#   param == 1/2 || throw("todo")
     return spectrum_tri(kxy...)
 end

--- a/src/triangle.jl
+++ b/src/triangle.jl
@@ -35,7 +35,7 @@ struct Triangle <: AbstractShape{2}
     end
 end
 #Triangle(param::T = 0.5) where {T <: Real} = Triangle{T}(param)
-Triangle(param::T = 0.5) where {T <: Real} = Triangle(param)
+#Triangle(param::T = 0.5) where {T <: Real} = Triangle(param)
 
 
 # constructors


### PR DESCRIPTION
Any extra parameters are a property of the *shape* and should be part of `Triangle` for example.
This simplifies code for all shapes that don't need any extra parameters.
And at this point there is no need for the extra parameter for Triangle either,
though that could be added in the future if needed.
(This is further refinement inspired by #30.)