### PR TITLE
Add `ℓmax` method

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Currently the package supports
 the following 2D shapes:
 ellipses/circles, rectangles/squares, gaussians, triangles,
 and the following 3D shapes:
-ellipsoids/spheres, cuboids/cubes, gaussians.
+ellipsoids/spheres, cuboids/cubes, gaussians, cylinders.
 
 
 ### Dependents

--- a/docs/lit/examples/32-ellipsoid.jl
+++ b/docs/lit/examples/32-ellipsoid.jl
@@ -55,7 +55,7 @@ All of the methods in `ImagePhantoms` support physical units,
 so we use such units throughout this example.
 (Using units is recommended but not required.)
 
-Here are 4 ways to define an `Object{Ellipsoid}`,
+Here are 3 ways to define an `Object{Ellipsoid}`,
 using physical units.
 =#
 
@@ -65,7 +65,6 @@ radii = (25mm, 35mm, 15mm)
 ϕ0 = eval(ϕ0s)
 angles = (ϕ0, 0)
 Object(Ellipsoid(), center, radii, angles, 1.0f0) # top-level constructor
-ellipsoid([20mm, 10mm, 5mm, 25mm, 35mm, 15mm, π/6, 0, 1.0f0]) # Vector{Number}
 ellipsoid( 20mm, 10mm, 5mm, 25mm, 35mm, 15mm, π/6, 0, 1.0f0 ) # 9 arguments
 ob = ellipsoid(center, radii, angles, 1.0f0) # tuples (recommended use)
 

--- a/docs/lit/examples/33-cuboid.jl
+++ b/docs/lit/examples/33-cuboid.jl
@@ -65,7 +65,6 @@ width = (35mm, 25mm, 15mm)
 ϕ0 = eval(ϕ0s)
 angles = (ϕ0, 0)
 Object(Cuboid(), center, width, angles, 1.0f0) # top-level constructor
-cuboid([10mm, 8mm, 6mm, 35mm, 25mm, 15mm, π/6, 0, 1.0f0]) # Vector{Number}
 cuboid( 10mm, 8mm, 6mm, 35mm, 25mm, 15mm, π/6, 0, 1.0f0 ) # 9 arguments
 ob = cuboid(center, width, angles, 1.0f0) # tuples (recommended use)
 

--- a/docs/lit/examples/34-gauss3.jl
+++ b/docs/lit/examples/34-gauss3.jl
@@ -65,8 +65,7 @@ width = (25mm, 35mm, 15mm)
 ϕ0 = eval(ϕ0s)
 angles = (ϕ0, 0)
 Object(Gauss3(), center, width, angles, 1.0f0) # top-level constructor
-gauss3([40mm, 20mm, 2mm, 25mm, 35mm, 12mm, π/6, 0, 1.0f0]) # Vector{Number}
-gauss3(20mm, 20mm, 2mm, 25mm, 35mm, 12mm, π/6, 0, 1.0f0) # 9 arguments
+gauss3(20mm, 10mm, 5mm, 25mm, 35mm, 15mm, π/6, 0, 1.0f0) # 9 arguments
 ob = gauss3(center, width, angles, 1.0f0) # tuples (recommended use)
 
 

--- a/docs/lit/examples/35-cylinder.jl
+++ b/docs/lit/examples/35-cylinder.jl
@@ -55,7 +55,7 @@ All of the methods in `ImagePhantoms` support physical units,
 so we use such units throughout this example.
 (Using units is recommended but not required.)
 
-Here are 4 ways to define a `Object{Cylinder}`,
+Here are 3 ways to define a `Object{Cylinder}`,
 using physical units.
 =#
 
@@ -65,7 +65,6 @@ width = (25mm, 35mm, 15mm) # x radius, y radius, height
 ϕ0 = eval(ϕ0s)
 angles = (ϕ0, 0)
 Object(Cylinder(), center, width, angles, 1.0f0) # top-level constructor
-cylinder([20mm, 10mm, 5mm, 25mm, 35mm, 15mm, π/6, 0, 1.0f0]) # Vector{Number}
 cylinder( 20mm, 10mm, 5mm, 25mm, 35mm, 15mm, π/6, 0, 1.0f0) # 9 arguments
 ob = cylinder(center, width, angles, 1.0f0) # tuples (recommended use)
 

--- a/src/cuboid.jl
+++ b/src/cuboid.jl
@@ -55,6 +55,10 @@ end
 
 volume1(::Cuboid) = 1 # volume of unit cube
 
+ℓmax1(::Cuboid) = √3 # max line integral through unit cuboid
+
+ℓmax(ob::Object3d{Cuboid}) = sqrt(sum(abs2, ob.width))
+
 
 """
     phantom1(ob::Object3d{Cuboid}, (x,y,z))

--- a/src/cuboid.jl
+++ b/src/cuboid.jl
@@ -22,7 +22,6 @@ struct Cuboid <: AbstractShape{3} end
 """
     cuboid(cx, cy, cz, wx, wy, wz, Φ, Θ, value::Number)
     cuboid(center::NTuple{3,RealU}, width::NTuple{3,RealU}, angle::NTuple{2,RealU}, v)
-    cuboid([9-vector])
 Construct `Object{Cuboid}` from parameters;
 here `width` is the full-width.
 """
@@ -34,7 +33,6 @@ cuboid(args... ; kwargs...) = Object(Cuboid(), args...; kwargs...)
 """
     cube(x, y, z, w, v=1) (cube of width `w` centered at `(x,y,z)`)
     cube((x,y,z), w, v=1) ditto
-    cube([5-vector]) ditto
     cube(w, v=1) centered at origin
 Construct cubes as special cases of `Cuboid`.
 """
@@ -43,11 +41,6 @@ cube(cx::RealU, cy::RealU, cz::RealU, w::RealU, v::Number = 1) =
 cube(center::NTuple{3,RealU}, w::RealU, v::Number = 1) =
     cube(center..., w, v)
 cube(w::RealU, v::Number = 1) = cube((zero(w), zero(w), zero(w)), v)
-
-function cube(v::AbstractVector{<:Number})
-    length(v) == 5 || throw(ArgumentError("$v wrong length"))
-    cube(v...)
-end
 
 
 # methods

--- a/src/cylinder.jl
+++ b/src/cylinder.jl
@@ -31,6 +31,10 @@ cylinder(args... ; kwargs...) = Object(Cylinder(), args...; kwargs...)
 
 volume1(::Cylinder) = π
 
+ℓmax1(::Cylinder) = √5 # max line integral through unit cylinder
+
+ℓmax(ob::Object3d{Cylinder}) = sqrt(sum(abs2, (2maximum(ob.width[1:2]), ob.width[3])))
+
 
 """
     phantom1(ob::Object3d{Cylinder}, (x,y,z))

--- a/src/cylinder.jl
+++ b/src/cylinder.jl
@@ -19,7 +19,6 @@ struct Cylinder <: AbstractShape{3} end
 """
     cylinder(cx, cy, cz, wx, wy, wz, Φ, Θ, value::Number)
     cylinder(center::NTuple{3,RealU}, width::NTuple{3,RealU}, angle::NTuple{2,RealU}, v)
-    cylinder([9-vector])
 Construct `Object{Cylinder}` from parameters;
 here `width` is the *radius* in x,y and the *height* in z.
 """

--- a/src/ellipse.jl
+++ b/src/ellipse.jl
@@ -53,6 +53,8 @@ end
 
 area1(::Ellipse) = π # area of unit circle
 
+ℓmax1(::Ellipse) = 2 # maximum chord through a unit circle
+
 
 """
     phantom1(ob::Object2d{Ellipse}, (x,y))

--- a/src/ellipse.jl
+++ b/src/ellipse.jl
@@ -21,7 +21,6 @@ struct Ellipse <: AbstractShape{2} end
 """
     ellipse(cx, cy, rx=1, ry=rx, ϕ=0, value::Number=1)
     ellipse(center::NTuple{2,RealU}, radii::NTuple{2,RealU}=(1,1), ϕ::RealU=0, v=1)
-    ellipse([6-vector])
 Construct `Object{Ellipse}` from parameters.
 """
 ellipse(args... ; kwargs...) = Object(Ellipse(), args...; kwargs...)
@@ -32,7 +31,6 @@ ellipse(args... ; kwargs...) = Object(Ellipse(), args...; kwargs...)
 """
     circle(x, y, r, v=1) (circle of radius `r` centered at `(x,y)`)
     circle((x,y), r=1, v=1) ditto
-    circle([4-vector]) ditto
     circle(r, v=1) centered at origin
 Construct circles as special cases of `Ellipse`.
 """
@@ -41,11 +39,6 @@ circle(cx::RealU, cy::RealU, r::RealU, v::Number = 1) =
 circle(center::NTuple{2,RealU}, r::RealU = oneunit(center[1]), v::Number = 1) =
     circle(center..., r, v)
 circle(r::RealU, v::Number = 1) = circle((zero(r), zero(r)), r, v)
-
-function circle(v::AbstractVector{<:Number})
-    length(v) == 4 || throw(ArgumentError("$v wrong length"))
-    circle(v...)
-end
 
 
 # methods

--- a/src/ellipsoid.jl
+++ b/src/ellipsoid.jl
@@ -21,7 +21,6 @@ struct Ellipsoid <: AbstractShape{3} end
 """
     ellipsoid(cx, cy, cz, rx=1, ry=1, rz=1, Φ=0, Θ=0, value::Number = 1)
     ellipsoid(center::NTuple{3,RealU}, radii::NTuple{3,RealU}, angle::NTuple{2,RealU}, v)
-    ellipsoid([9-vector])
 Construct `Object{Ellipsoid}` from parameters.
 """
 ellipsoid(args... ; kwargs...) = Object(Ellipsoid(), args...; kwargs...)
@@ -32,7 +31,6 @@ ellipsoid(args... ; kwargs...) = Object(Ellipsoid(), args...; kwargs...)
 """
     sphere(x, y, z, r,v=1) (sphere of radius `r` centered at `(x,y,z)`)
     sphere((x,y,z), r, v=1) ditto
-    sphere([5-vector]) ditto
     sphere(r, v=1) centered at origin
 Construct spheres as special cases of `Ellipsoid`.
 """
@@ -41,11 +39,6 @@ sphere(cx::RealU, cy::RealU, cz::RealU, r::RealU, v::Number = 1) =
 sphere(center::NTuple{3,RealU}, r::RealU, v::Number = 1) =
     sphere(center..., r, v)
 sphere(r::RealU, v::Number = 1) = sphere((zero(r), zero(r), zero(r)), v)
-
-function sphere(v::AbstractVector{<:Number})
-    length(v) == 5 || throw(ArgumentError("$v wrong length"))
-    sphere(v...)
-end
 
 
 # methods

--- a/src/ellipsoid.jl
+++ b/src/ellipsoid.jl
@@ -53,6 +53,8 @@ end
 
 volume1(::Ellipsoid) = 4/3 * π # volume of unit sphere
 
+ℓmax1(::Ellipsoid) = 2 # maximum chord through a unit sphere
+
 
 """
     phantom1(ob::Object3d{Ellipsoid}, (x,y,z))

--- a/src/gauss2.jl
+++ b/src/gauss2.jl
@@ -21,7 +21,6 @@ struct Gauss2 <: AbstractShape{2} end
 """
     gauss2(cx, cy, wx, wy=wx, ϕ=0, value::Number=1)
     gauss2(center::NTuple{2,RealU}, width::NTuple{2,RealU}=(1,1), ϕ::RealU=0, v=1)
-    gauss2([6-vector])
     gauss2(w, v=1) (isotropic of width `w`)
 Construct `Object{Gauss2}` from parameters;
 here `width` = FWHM (full-width at half-maximum).

--- a/src/gauss2.jl
+++ b/src/gauss2.jl
@@ -55,6 +55,8 @@ Convert FWHM `w` to equivalent Gaussian spread `s` for ``\\exp(-π (x/s)^2)``.
 
 area1(::Gauss2) = fwhm2spread(1)^2
 
+ℓmax1(::Gauss2) = fwhm2spread(1) # max line integral through a unit gauss2
+
 
 """
     phantom1(ob::Object2d{Gauss2}, (x,y))

--- a/src/gauss3.jl
+++ b/src/gauss3.jl
@@ -21,7 +21,6 @@ struct Gauss3 <: AbstractShape{3} end
 """
     gauss3(cx, cy, cz, wx, wy, wz, Φ=0, Θ=0, value::Number = 1)
     gauss3(center::NTuple{3,RealU}, radii::NTuple{3,RealU}=(1,1,1), angle::NTuple{2,RealU}=(0,0), v=1)
-    gauss3([9-vector])
     gauss3(r, v=1) (isotropic of width `w`)
 Construct `Object{Gauss3}` from parameters;
 here `width` = FWHM (full-width at half-maximum).

--- a/src/gauss3.jl
+++ b/src/gauss3.jl
@@ -34,6 +34,8 @@ gauss3(args... ; kwargs...) = Object(Gauss3(), args...; kwargs...)
 
 volume1(::Gauss3) = fwhm2spread(1)^3
 
+ℓmax1(::Gauss3) = fwhm2spread(1) # max line integral through a unit gauss2
+
 
 """
     phantom1(ob::Object3d{Gauss3}, (x,y,z))

--- a/src/object.jl
+++ b/src/object.jl
@@ -121,7 +121,6 @@ end
 
 """
     Object(shape ; cx, cy, wx=1, wy=wx, ϕ=0, value=1)
-    Object(shape ; [6-vector])
 2D object constructor from values (without tuples).
 """
 function Object(
@@ -136,15 +135,9 @@ function Object(
     Object(shape, (cx, cy), (wx, wy), (ϕ,), value)
 end
 
-function Object(shape::AbstractShape{2}, v::AbstractVector ; kwargs...)
-    length(v) == 6 || throw(ArgumentError("2D object needs 6 parameters"))
-    return Object(shape, v...; kwargs...)
-end
-
 
 """
     Object(shape ; cx, cy, cz, wx=1, wy=wx, wz=wx, ϕ=0, θ=0, value=1)
-    Object(shape ; [9-vector])
 3D object constructor from values (without tuples).
 """
 function Object(
@@ -160,11 +153,6 @@ function Object(
     value::Number = 1,
 ) where {C <: RealU}
     Object(shape, (cx, cy, cz), (wx, wy, wz), (ϕ, θ), value)
-end
-
-function Object(shape::AbstractShape{3}, p::AbstractVector ; kwargs...)
-    length(p) == 9 || throw(ArgumentError("3D object needs 9 parameters"))
-    return Object(shape, p...; kwargs...)
 end
 
 

--- a/src/object2.jl
+++ b/src/object2.jl
@@ -9,6 +9,8 @@ export phantom, radon, spectrum
 
 area(ob::Object2d{S}) where S = area1(S()) * prod(ob.width)
 
+ℓmax(ob::Object2d{S}) where S = ℓmax1(S()) * maximum(ob.width)
+
 
 # rotate
 

--- a/src/object3.jl
+++ b/src/object3.jl
@@ -9,6 +9,8 @@ export phantom, radon, spectrum
 
 volume(ob::Object3d{S}) where S = volume1(S()) * prod(ob.width)
 
+ℓmax(ob::Object3d{S}) where S = ℓmax1(S()) * maximum(ob.width)
+
 
 # rotate
 

--- a/src/rect.jl
+++ b/src/rect.jl
@@ -75,6 +75,10 @@ end
 
 area1(::Rect) = 1 # area of unit square
 
+ℓmax1(::Rect) = √2 # max line integral through unit square
+
+ℓmax(ob::Object2d{Rect}) = sqrt(sum(abs2, ob.width))
+
 
 """
     phantom1(ob::Object2d{Rect}, (x,y))

--- a/src/rect.jl
+++ b/src/rect.jl
@@ -21,7 +21,6 @@ struct Rect <: AbstractShape{2} end
 """
     rect(cx, cy, wx=1, wy=wx, ϕ=0, value::Number=1)
     rect(center::NTuple{2,RealU}, width::NTuple{2,RealU}=(1,1), ϕ::RealU=0, v=1)
-    rect([6-vector])
 Construct `Object{Rect}` from parameters;
 here `width` is the full-width.
 """
@@ -33,7 +32,6 @@ rect(args... ; kwargs...) = Object(Rect(), args...; kwargs...)
 """
     square(x, y, w,v=1) (square of width `w` centered at `(x,y)`)
     square((x,y), w=1, v=1) ditto
-    square([4-vector]) ditto
     square(w, v=1) centered at origin
 Construct squares as special cases of `Rect`.
 """
@@ -42,11 +40,6 @@ square(cx::RealU, cy::RealU, w::RealU, v::Number = 1) =
 square(center::NTuple{2,RealU}, w::RealU = oneunit(center[1]), v::Number = 1) =
     square(center..., w, v)
 square(w::RealU, v::Number = 1) = square((zero(w), zero(w)), w, v)
-
-function square(v::AbstractVector{<:Number})
-    length(v) == 4 || throw(ArgumentError("$v wrong length"))
-    square(v...)
-end
 
 
 # helper

--- a/src/shepplogan.jl
+++ b/src/shepplogan.jl
@@ -68,7 +68,7 @@ Return vector of `Object{Ellipse}`, one for each row of input matrix.
 """
 function ellipse(params::AbstractMatrix{<:RealU})
     size(params,2) == 6 || throw("ellipses need 6 parameters")
-    return [ellipse(params[n,:]) for n in 1:size(params,1)]
+    return [ellipse(params[n,:]...) for n in 1:size(params,1)]
 end
 
 function shepp_logan(case::EllipsePhantomVersion; kwargs...)
@@ -80,7 +80,7 @@ end
     image = shepp_logan(M, [N,], case, options...)
 Convenience method for generating `M×N` samples of Shepp-Logan phantoms.
 
-In
+# In
 * `M::Int` : horizontal size
 * `N::Int` : vertical size, defaults to `M`
 * `case::EllipsePhantomVersion = SheppLogan()`
@@ -133,7 +133,7 @@ If `disjoint==true` then the middle ellipse positions are adjusted to avoid over
 function ellipse_parameters(
     case::EllipsePhantomVersion = SheppLogan() ;
     fovs::NTuple{2,RealU} = (1,1),
-    u::NTuple{3,Any} = (1,1,1), # unit scaling
+    u::NTuple{3,Number} = (1,1,1), # unit scaling
     disjoint::Bool = false,
 )
     (xfov, yfov) = fovs

--- a/src/triangle.jl
+++ b/src/triangle.jl
@@ -127,6 +127,13 @@ end
 
 area1(::Triangle) = sqrt(3)/4 # area of unit base equilateral
 
+ℓmax1(::Triangle) = 1
+
+ℓmax(ob::Object2d{Triangle}) = sqrt(
+    (ob.width[1]/2)^2 +
+    (ob.width[2] * sqrt(3) / 2)^2
+)
+
 
 """
     phantom1(ob::Object2d{Triangle}, (x,y))

--- a/src/triangle.jl
+++ b/src/triangle.jl
@@ -44,7 +44,6 @@ end
 """
     triangle(cx, cy, wx=1, wy=wx, ϕ=0, value::Number=1, param::Real=0.5)
     triangle(center::NTuple{2,RealU}, width::NTuple{2,RealU}=(1,1), ϕ::RealU=0, v=1, param=0.5)
-    triangle([6-vector])
 Construct `Object{Triangle}` from parameters.
 In the typical case where `param=0.5` and `width[1] == width[2]`,
 this is an equilateral triangle with base `width[1]` centered along the x axis.

--- a/test/core.jl
+++ b/test/core.jl
@@ -31,7 +31,6 @@ using Test: @test, @testset, @test_throws, @inferred
     @test spectrum([ob]) isa Function
     @test spectrum([ob])(0,0) ≈ π
     @test spectrum(zeros(2), zeros(3), [ob]) ≈ π*ones(2,3)
-
 end
 
 

--- a/test/cuboid.jl
+++ b/test/cuboid.jl
@@ -77,6 +77,8 @@ end
     show(devnull, ob)
     @test (@inferred eltype(ob)) == Float32
 
+    @test (@inferred IP.ℓmax(ob)) ≈ sqrt(4^2 + 5^2 + 6^2)
+    @test (@inferred IP.ℓmax1(Shape())) ≈ √3
 
     fun = @inferred phantom(ob)
     @test fun isa Function

--- a/test/cuboid.jl
+++ b/test/cuboid.jl
@@ -39,13 +39,11 @@ end
     @isob3 @inferred Object(Shape(), center=(1,2,3))
     @isob3 @inferred shape((1,2.,3), (4,5//1,6), (π, π/4), 5.0f0)
     @isob3 @inferred shape(1, 2., 3, 4//1, 5, 6., π, π/4, 5.0f0)
-    @isob3 @NOTinferred shape(Number[1, 2., 3, 4//1, 5, 6., π, π/4, 5.0f0])
 
     # cubes
     @isob3 @inferred shape3(1, 5.0f0)
     @isob3 @inferred shape3(1, 2, 3, 4., 5.0f0)
     @isob3 @inferred shape3((1, 2, 3), 4., 5.0f0)
-    @isob3 @NOTinferred shape3(Number[1, 2, 3, 4., 5.0f0])
 end
 
 

--- a/test/cylinder.jl
+++ b/test/cylinder.jl
@@ -58,6 +58,8 @@ end
     show(devnull, ob)
     @test (@inferred eltype(ob)) == Float32
 
+    @test (@inferred IP.ℓmax(ob)) ≈ sqrt(10^2 + 6^2)
+    @test (@inferred IP.ℓmax1(Shape())) ≈ √5
 
     fun = @inferred phantom(ob)
     @test fun isa Function

--- a/test/cylinder.jl
+++ b/test/cylinder.jl
@@ -26,7 +26,6 @@ end
     @isob3 @inferred shape((1,2.,3), (4,5//1,6), (π, π/4), 5.0f0)
     @isob3 @inferred shape(1, 2., 3, 4//1, 5, 6., π, π/4, 5.0f0)
 #   @isob3 @inferred shape(1, 5.0f0)
-    @isob3 @NOTinferred shape(Number[1, 2., 3, 4//1, 5, 6., π, π/4, 5.0f0])
 end
 
 

--- a/test/ellipse.jl
+++ b/test/ellipse.jl
@@ -34,14 +34,12 @@ end
     @isob @inferred Object(Shape(), center=(1,2))
     @isob @inferred shape((1,2.), (3,4//1), π, 5.0f0)
     @isob @inferred shape(1, 2., 3, 4//1, π, 5.0f0)
-    @isob @NOTinferred shape(Number[1, 2., 3, 4//1, π, 5.0f0])
 
     # circles
     @isob @inferred shape(1, 5.0f0)
     @isob @inferred shape2(1, 5.0f0)
     @isob @inferred shape2(1, 2, 3., 5.0f0)
     @isob @inferred shape2((1, 2), 3., 5.0f0)
-    @isob @NOTinferred shape2(Number[1, 2, 3., 5.0f0])
 end
 
 

--- a/test/ellipse.jl
+++ b/test/ellipse.jl
@@ -61,6 +61,7 @@ end
     @isob @inferred IP.scale(ob, 2)
     @isob @inferred IP.translate(ob, (2, 3))
     @isob @inferred IP.translate(ob, 2, 3)
+
 end
 
 
@@ -71,6 +72,9 @@ end
 
     show(devnull, ob)
     @test (@inferred eltype(ob)) == Float32
+
+    @test (@inferred IP.ℓmax(ob)) == 8
+    @test (@inferred IP.ℓmax1(Shape())) > 0
 
     fun = @inferred phantom(ob)
     @test fun isa Function

--- a/test/ellipse.jl
+++ b/test/ellipse.jl
@@ -2,21 +2,12 @@
 ellipse.jl
 =#
 
-const DEBUG = false
-
 using ImagePhantoms: Object, Object2d, AbstractShape, phantom, radon, spectrum
 using ImagePhantoms: Ellipse, ellipse, circle
 import ImagePhantoms as IP
 using Unitful: m, unit, °
 using FFTW: fftshift, fft
 using Test: @test, @testset, @test_throws, @inferred
-if DEBUG
-    include("helper.jl")
-    using MIRTjim: jim, prompt
-    using UnitfulRecipes
-    using Plots: plot, plot!, scatter, scatter!, gui, default
-    default(markerstrokecolor=:auto, markersize=2)
-end
 
 (Shape, shape, shape2) = (Ellipse, ellipse, circle)
 
@@ -127,16 +118,6 @@ end
     X = myfft(img) * dx * dy * zscale
     kspace = @inferred spectrum(fx, fy, [ob]) * zscale
 
-if DEBUG
-    clim = (-6, 0)
-    sp = z -> max(log10(abs(z)/oneunit(abs(z))), -6)
-    p1 = jim(x, y, img, "phantom")
-    p2 = jim(fx, fy, sp.(X), "log10|DFT|"; clim)
-    p3 = jim(fx, fy, sp.(kspace), "log10|Spectrum|"; clim)
-    p4 = jim(fx, fy, abs.(kspace - X), "Difference")
-    jim(p1, p4, p2, p3); prompt()
-end
-
     @test abs(maximum(abs, X) - 1) < 1e-6
     @test abs(maximum(abs, kspace) - 1) < 1e-5
     @test maximum(abs, kspace - X) / maximum(abs, kspace) < 6e-4
@@ -158,21 +139,6 @@ end
 
     kx, ky = (fr * cos(ϕ[ia]), fr * sin(ϕ[ia])) # Fourier-slice theorem
     ideal = spectrum(ob).(kx, ky)
-
-if DEBUG
-    p2 = jim(r, rad2deg.(ϕ), sino; aspect_ratio=:none, title="sinogram")
-    jim(p1, p2)
-    p3 = plot(r, slice, title="profile at ϕ = $angle", label="")
-    p4 = scatter(fr, abs.(Slice), label="abs fft", color=:blue)
-    scatter!(fr, real(Slice), label="real fft", color=:green)
-    scatter!(fr, imag(Slice), label="imag fft", color=:red,
-        xlims=(-1,1).*(1.2/m), title="1D spectra")
-
-    plot!(fr, abs.(ideal), label="abs", color=:blue)
-    plot!(fr, real(ideal), label="real", color=:green)
-    plot!(fr, imag(ideal), label="imag", color=:red)
-    plot(p1, p2, p3, p4); gui()
-end
 
     @test maximum(abs, ideal - Slice) / maximum(abs, ideal) < 2e-4
 end

--- a/test/ellipse.jl
+++ b/test/ellipse.jl
@@ -74,7 +74,7 @@ end
     @test (@inferred eltype(ob)) == Float32
 
     @test (@inferred IP.ℓmax(ob)) == 8
-    @test (@inferred IP.ℓmax1(Shape())) > 0
+    @test (@inferred IP.ℓmax1(Shape())) == 2
 
     fun = @inferred phantom(ob)
     @test fun isa Function
@@ -82,6 +82,7 @@ end
     @test fun((ob.center .+ 2 .* ob.width)...) == 0
 
     img = @inferred phantom(x, y, [ob])
+
 
     fun = @inferred radon(ob)
     @test fun isa Function

--- a/test/ellipsoid.jl
+++ b/test/ellipsoid.jl
@@ -63,6 +63,8 @@ end
     show(devnull, ob)
     @test (@inferred eltype(ob)) == Float32
 
+    @test (@inferred IP.ℓmax(ob)) == 12
+    @test (@inferred IP.ℓmax1(Shape())) == 2
 
     fun = @inferred phantom(ob)
     @test fun isa Function

--- a/test/ellipsoid.jl
+++ b/test/ellipsoid.jl
@@ -25,13 +25,11 @@ end
     @isob3 @inferred Object(Shape(), center=(1,2,3))
     @isob3 @inferred shape((1,2.,3), (4,5//1,6), (π, π/4), 5.0f0)
     @isob3 @inferred shape(1, 2., 3, 4//1, 5, 6., π, π/4, 5.0f0)
-    @isob3 @NOTinferred shape(Number[1, 2., 3, 4//1, 5, 6., π, π/4, 5.0f0])
 
     # spheres
     @isob3 @inferred shape3(1, 5.0f0)
     @isob3 @inferred shape3(1, 2, 3, 4., 5.0f0)
     @isob3 @inferred shape3((1, 2, 3), 4., 5.0f0)
-    @isob3 @NOTinferred shape3(Number[1, 2, 3, 4., 5.0f0])
 end
 
 

--- a/test/gauss2.jl
+++ b/test/gauss2.jl
@@ -34,7 +34,6 @@ end
     @isob @inferred Object(Shape(), center=(1,2))
     @isob @inferred shape((1,2.), (3,4//1), π, 5.0f0)
     @isob @inferred shape(1, 2., 3, 4//1, π, 5.0f0)
-    @isob @NOTinferred shape(Number[1, 2., 3, 4//1, π, 5.0f0])
     @isob @inferred shape(1, 5.0f0)
 end
 

--- a/test/gauss2.jl
+++ b/test/gauss2.jl
@@ -2,21 +2,12 @@
 gauss2.jl
 =#
 
-const DEBUG = false
-
 using ImagePhantoms: Object, Object2d, AbstractShape, phantom, radon, spectrum
 using ImagePhantoms: Gauss2, gauss2
 import ImagePhantoms as IP
 using Unitful: m, unit, °
 using FFTW: fftshift, fft
 using Test: @test, @testset, @test_throws, @inferred
-if DEBUG
-    include("helper.jl")
-    using MIRTjim: jim, prompt
-    using UnitfulRecipes
-    using Plots: plot, plot!, scatter, scatter!, gui, default
-    default(markerstrokecolor=:auto, markersize=2)
-end
 
 (Shape, shape) = (Gauss2, gauss2)
 
@@ -90,14 +81,6 @@ end
     ob = @inferred shape((0, 0), (fwhm, Inf), 0, 1)
     tmp = @inferred phantom((-1:1)*fwhm/2, [0], [ob])
     @test tmp ≈ [0.5, 1, 0.5]
-
-if DEBUG # check profile
-    x = -2fwhm:2fwhm
-    profile = @inferred phantom(x, [0], [ob])
-    scatter(x, profile, label="profile")
-    scatter!([-1,1]*fwhm/2, [1,1]*0.5, label="fwhm/2")
-#   prompt()
-end
 end
 
 
@@ -116,16 +99,6 @@ end
     fy = (-N÷2:N÷2-1) / N / dy
     X = myfft(img) * dx * dy * zscale
     kspace = @inferred spectrum(fx, fy, [ob]) * zscale
-
-if DEBUG
-    clim = (-6, 0)
-    sp = z -> max(log10(abs(z)/oneunit(abs(z))), -6)
-    p1 = jim(x, y, img, "phantom")
-    p2 = jim(fx, fy, sp.(X), "log10|DFT|"; clim)
-    p3 = jim(fx, fy, sp.(kspace), "log10|Spectrum|"; clim)
-    p4 = jim(fx, fy, 1e6*abs.(kspace - X), "Difference * 1e6")
-    jim(p1, p4, p2, p3); prompt()
-end
 
     @test abs(maximum(abs, X) - 1) < 1e-6
     @test abs(maximum(abs, kspace) - 1) < 1e-6
@@ -148,22 +121,6 @@ end
 
     kx, ky = (fr * cos(ϕ[ia]), fr * sin(ϕ[ia])) # Fourier-slice theorem
     ideal = spectrum(ob).(kx, ky)
-
-if DEBUG
-    @show maximum(abs, ideal - Slice) / maximum(abs, ideal)
-    p2 = jim(r, rad2deg.(ϕ), sino; aspect_ratio=:none, title="sinogram")
-    jim(p1, p2)
-    p3 = plot(r, slice, title="profile at ϕ = $angle", label="")
-    p4 = scatter(fr, abs.(Slice), label="abs fft", color=:blue)
-    scatter!(fr, real(Slice), label="real fft", color=:green)
-    scatter!(fr, imag(Slice), label="imag fft", color=:red,
-        xlims=(-1,1).*(1.2/m), title="1D spectra")
-
-    plot!(fr, abs.(ideal), label="abs", color=:blue)
-    plot!(fr, real(ideal), label="real", color=:green)
-    plot!(fr, imag(ideal), label="imag", color=:red)
-    plot(p1, p2, p3, p4); gui()
-end
 
     @test maximum(abs, ideal - Slice) / maximum(abs, ideal) < 4e-4
 end

--- a/test/gauss2.jl
+++ b/test/gauss2.jl
@@ -66,6 +66,9 @@ end
     show(devnull, ob)
     @test (@inferred eltype(ob)) == Float32
 
+    @test (@inferred IP.ℓmax(ob)) ≈ IP.fwhm2spread(4)
+    @test (@inferred IP.ℓmax1(Shape())) > 0
+
     fun = @inferred phantom(ob)
     @test fun isa Function
     @test fun(ob.center...) == ob.value

--- a/test/gauss2.jl
+++ b/test/gauss2.jl
@@ -76,6 +76,7 @@ end
 
     img = @inferred phantom(x, y, [ob])
 
+
     fun = @inferred radon(ob)
     @test fun isa Function
     fun(0,0)

--- a/test/gauss3.jl
+++ b/test/gauss3.jl
@@ -26,7 +26,6 @@ end
     @isob3 @inferred shape((1,2.,3), (4,5//1,6), (π, π/4), 5.0f0)
     @isob3 @inferred shape(1, 2., 3, 4//1, 5, 6., π, π/4, 5.0f0)
 #   @isob3 @inferred shape(1, 5.0f0)
-    @isob3 @NOTinferred shape(Number[1, 2., 3, 4//1, 5, 6., π, π/4, 5.0f0])
 end
 
 

--- a/test/gauss3.jl
+++ b/test/gauss3.jl
@@ -58,6 +58,8 @@ end
     show(devnull, ob)
     @test (@inferred eltype(ob)) == Float32
 
+    @test (@inferred IP.ℓmax(ob)) ≈ IP.fwhm2spread(6)
+    @test (@inferred IP.ℓmax1(Shape())) ≈ IP.fwhm2spread(1)
 
     fun = @inferred phantom(ob)
     @test fun isa Function

--- a/test/mri-sense.jl
+++ b/test/mri-sense.jl
@@ -1,7 +1,5 @@
 # mri-sense.jl test
 
-const DEBUG = false
-
 using ImagePhantoms: ellipse_parameters, SheppLoganBrainWeb, ellipse
 using ImagePhantoms: phantom, spectrum
 using ImagePhantoms: mri_smap_fit, mri_spectra
@@ -12,14 +10,6 @@ using ImageGeoms: embed
 using LazyGrids: ndgrid
 using LinearAlgebra: norm
 using Test: @test, @testset, @test_throws, @inferred
-
-if DEBUG
-    include("helper.jl")
-    using MIRTjim: jim, prompt; jim(:prompt, true)
-else
-    jim(args...; kwargs...) = nothing
-end
-jimf = (args...; kwargs...) -> jim(args...; prompt=false, kwargs...)
 
 # image geometry
 fovs = (256mm, 250mm)
@@ -36,7 +26,6 @@ oa = ellipse(oa)
 oversample = 3
 image0 = phantom(x, y, oa, oversample)
 cfun = z -> cat(dims = ndims(z)+1, real(z), imag(z))
-jim(x, y, cfun(image0), "image0")
 
 @test spectrum(oa[1]) isa Function
 
@@ -45,7 +34,6 @@ mask = trues(nx,ny)
 mask[:,1:2] .= false
 mask[[1:8;end-8:end],:] .= false
 @assert mask .* image0 == image0
-jim(x, y, mask, "mask")
 
 # sensitivity maps (smaps) (not normalized)
 ncoil = 2
@@ -56,7 +44,6 @@ smap = cat(dims=3,
 smap .*= mask
 stacker = x -> [(@view x[:,:,i]) for i=1:size(x,3)]
 smaps = stacker(smap)
-jim(x, y, cfun(smaps), "Sensitivity maps")
 
 
 # fit each smap
@@ -66,14 +53,7 @@ fit = @NOTinferred mri_smap_fit(smaps, embed; mask, kmax, deltas)
 @test fit isa NamedTuple
 @test fit.nrmse ≤ 1e-6
 
-jim(
- jim(x, y, cfun(smaps), "orig"; prompt=false),
- jim(x, y, cfun(fit.smaps), "fit"; prompt=false),
- jim(x, y, cfun(1e6*(fit.smaps - smaps)), "err * 1e6"; prompt=false),
-)
-
 coefs = map(x -> reshape(x,15,15), fit.coefs)
-jim(-kmax:kmax, -kmax:kmax, cfun(coefs), "coefs")
 
 fx = (-(nx÷2):(nx÷2-1)) / (nx*dx) # crucial to match smap_basis internals!
 fy = (-(ny÷2):(ny÷2-1)) / (ny*dy)
@@ -95,12 +75,6 @@ kspace1 = spectrum(fx, fy, [ob])
 
 kspace1 = myfft(image1) * dx * dy
 
-jim(
- jimf(fx, fy, cfun(kspace0), "analytical"),
- jimf(fx, fy, cfun(kspace1), "fft"),
- jimf(fx, fy, cfun(kspace1 - kspace0), "error"),
-)
-
 #@test norm
 =#
 
@@ -108,20 +82,10 @@ jim(
 # test one object with one smap
 
 image2 = image1 .* smaps[coil] # digital
-jim(
- jimf(x, y, cfun(image1), "complex image"),
- jimf(x, y, cfun(image2), "with smap"),
- jimf(x, y, cfun(smaps[coil]), "smaps"),
-)
 
 kspace2 = myfft(image2) * dx * dy
 fun = spectrum(ob, fit, coil)
 kspace3 = fun.(fx, fy')
-jim(
- jimf(fx, fy, cfun(kspace2), "fft"),
- jimf(fx, fy, cfun(kspace3), "analytical"),
- jimf(fx, fy, cfun(kspace3 - kspace2), "err"),
-)
 
 @test norm(kspace3 - kspace2) / norm(kspace2) ≤ 0.09
 
@@ -138,14 +102,6 @@ kspace1 = [reshape(k, nx, ny) for k in kspace1]
 
 image2 = [image0 .* s for s in smaps] # digital
 kspace2 = myfft.(image2) * (dx * dy)
-
-#p0 = jim(fx, fy, cfun(kspace0), "kspace0: before smap"; prompt=false)
-jim(
- jimf(x, y, image0, "image0"),
- jimf(fx, fy, cfun(kspace1), "anal with smaps"),
- jimf(fx, fy, cfun(kspace2), "fft with smaps"),
- jimf(fx, fy, cfun(kspace2 - kspace1), "error"),
-)
 
 norma = za -> sqrt(sum(abs2, norm.(za))) # for array of arrays
 @test norma(kspace2 - kspace1) / norma(kspace2) ≤ 0.03

--- a/test/rect.jl
+++ b/test/rect.jl
@@ -72,6 +72,9 @@ end
     show(devnull, ob)
     @test (@inferred eltype(ob)) == Float32
 
+    @test (@inferred IP.ℓmax(ob)) ≈ 5
+    @test (@inferred IP.ℓmax1(Shape())) > 0
+
     fun = @inferred phantom(ob)
     @test fun isa Function
     @test fun(ob.center...) == ob.value

--- a/test/rect.jl
+++ b/test/rect.jl
@@ -73,7 +73,7 @@ end
     @test (@inferred eltype(ob)) == Float32
 
     @test (@inferred IP.ℓmax(ob)) ≈ 5
-    @test (@inferred IP.ℓmax1(Shape())) > 0
+    @test (@inferred IP.ℓmax1(Shape())) ≈ √2
 
     fun = @inferred phantom(ob)
     @test fun isa Function
@@ -81,6 +81,7 @@ end
     @test fun((ob.center .+ 2 .* ob.width)...) == 0
 
     img = @inferred phantom(x, y, [ob])
+
 
     fun = @inferred radon(ob)
     @test fun isa Function

--- a/test/rect.jl
+++ b/test/rect.jl
@@ -2,21 +2,12 @@
 rect.jl
 =#
 
-const DEBUG = false
-
 using ImagePhantoms: Object, Object2d, AbstractShape, phantom, radon, spectrum
 using ImagePhantoms: Rect, rect, square
 import ImagePhantoms as IP
 using Unitful: m, unit, °
 using FFTW: fftshift, fft
 using Test: @test, @testset, @test_throws, @inferred
-if DEBUG
-    include("helper.jl")
-    using MIRTjim: jim, prompt
-    using UnitfulRecipes
-    using Plots: plot, plot!, scatter, scatter!, gui, default
-    default(markerstrokecolor=:auto, markersize=2)
-end
 
 (Shape, shape, shape2) = (Rect, rect, square)
 
@@ -36,7 +27,6 @@ end
     @isob @inferred shape(1, 2., 3, 4//1, π, 5.0f0)
 
     # squares
-    @isob @inferred shape(1, 5.0f0)
     @isob @inferred shape2(1, 5.0f0)
     @isob @inferred shape2(1, 2, 3., 5.0f0)
     @isob @inferred shape2((1, 2), 3., 5.0f0)
@@ -79,9 +69,11 @@ end
     @test fun((ob.center .+ 2 .* ob.width)...) == 0
 
     img = @inferred phantom(x, y, [ob])
+    @test img isa Array{<:Real, 2}
+    @test size(img) == length.((x, y))
 
 
-    fun = @inferred radon(ob)
+    fun = @inferred radon([ob])
     @test fun isa Function
     fun(0,0)
 
@@ -106,16 +98,6 @@ end
     X = myfft(img) * dx * dy * zscale
     kspace = @inferred spectrum(fx, fy, [ob]) * zscale
 
-if DEBUG
-    clim = (-6, 0)
-    sp = z -> max(log10(abs(z)/oneunit(abs(z))), -6)
-    p1 = jim(x, y, img, "phantom")
-    p2 = jim(fx, fy, sp.(X), "log10|DFT|"; clim)
-    p3 = jim(fx, fy, sp.(kspace), "log10|Spectrum|"; clim)
-    p4 = jim(fx, fy, abs.(kspace - X), "Difference")
-    jim(p1, p4, p2, p3); prompt()
-end
-
     @test abs(maximum(abs, X) - 1) < 2e-4
     @test abs(maximum(abs, kspace) - 1) < 1e-5
     @test maximum(abs, kspace - X) / maximum(abs, kspace) < 6e-3
@@ -137,21 +119,6 @@ end
 
     kx, ky = (fr * cos(ϕ[ia]), fr * sin(ϕ[ia])) # Fourier-slice theorem
     ideal = spectrum(ob).(kx, ky)
-
-if DEBUG
-    p2 = jim(r, rad2deg.(ϕ), sino; aspect_ratio=:none, title="sinogram")
-    jim(p1, p2)
-    p3 = plot(r, slice, title="profile at ϕ = $angle", label="")
-    p4 = scatter(fr, abs.(Slice), label="abs fft", color=:blue)
-    scatter!(fr, real(Slice), label="real fft", color=:green)
-    scatter!(fr, imag(Slice), label="imag fft", color=:red,
-        xlims=(-1,1).*(1.2/m), title="1D spectra")
-
-    plot!(fr, abs.(ideal), label="abs", color=:blue)
-    plot!(fr, real(ideal), label="real", color=:green)
-    plot!(fr, imag(ideal), label="imag", color=:red)
-    plot(p1, p2, p3, p4); gui()
-end
 
     @test maximum(abs, ideal - Slice) / maximum(abs, ideal) < 3e-5
 end

--- a/test/rect.jl
+++ b/test/rect.jl
@@ -34,14 +34,12 @@ end
     @isob @inferred Object(Shape(), center=(1,2))
     @isob @inferred shape((1,2.), (3,4//1), π, 5.0f0)
     @isob @inferred shape(1, 2., 3, 4//1, π, 5.0f0)
-    @isob @NOTinferred shape(Number[1, 2., 3, 4//1, π, 5.0f0])
 
     # squares
     @isob @inferred shape(1, 5.0f0)
     @isob @inferred shape2(1, 5.0f0)
     @isob @inferred shape2(1, 2, 3., 5.0f0)
     @isob @inferred shape2((1, 2), 3., 5.0f0)
-    @isob @NOTinferred shape2(Number[1, 2, 3., 5.0f0])
 end
 
 

--- a/test/triangle.jl
+++ b/test/triangle.jl
@@ -34,7 +34,6 @@ end
     @isob @inferred Object(Shape(), center=(1,2))
     @isob @inferred shape((1,2.), (3,4//1), π, 5.0f0)
     @isob @inferred shape(1, 2., 3, 4//1, π, 5.0f0)
-    @isob @NOTinferred shape(Number[1, 2., 3, 4//1, π, 5.0f0])
     @isob @inferred shape(1, 5.0f0)
 end
 

--- a/test/triangle.jl
+++ b/test/triangle.jl
@@ -74,6 +74,9 @@ end
     show(devnull, ob)
     @test (@inferred eltype(ob)) == Float32
 
+    @test (@inferred IP.ℓmax(ob)) ≈ sqrt((4/2)^2 + (3 * sqrt(3) / 2)^2)
+    @test (@inferred IP.ℓmax1(Shape())) > 0
+
     fun = @inferred phantom(ob)
     @test fun isa Function
     @test fun(ob.center...) == ob.value

--- a/test/triangle.jl
+++ b/test/triangle.jl
@@ -2,21 +2,12 @@
 triangle.jl
 =#
 
-const DEBUG = false
-
 using ImagePhantoms: Object, Object2d, AbstractShape, phantom, radon, spectrum
 using ImagePhantoms: Triangle, triangle
 import ImagePhantoms as IP
 using Unitful: m, unit, °
 using FFTW: fftshift, fft
 using Test: @test, @testset, @test_throws, @inferred
-if DEBUG
-    include("helper.jl")
-    using MIRTjim: jim, prompt
-    using UnitfulRecipes
-    using Plots: plot, plot!, scatter, scatter!, gui, default
-    default(markerstrokecolor=:auto, markersize=2)
-end
 
 (Shape, shape) = (Triangle, triangle)
 
@@ -108,16 +99,6 @@ end
     X = myfft(img) * dx * dy * zscale
     kspace = @inferred spectrum(fx, fy, [ob]) * zscale
 
-if DEBUG
-    clim = (-6, 0)
-    sp = z -> max(log10(abs(z)/oneunit(abs(z))), -6)
-    p1 = jim(x, y, img, "phantom")
-    p2 = jim(fx, fy, sp.(X), "log10|DFT|"; clim)
-    p3 = jim(fx, fy, sp.(kspace), "log10|Spectrum|"; clim)
-    p4 = jim(fx, fy, abs.(kspace - X), "Difference")
-    jim(p1, p4, p2, p3); prompt()
-end
-
     @test abs(maximum(abs, X) - 1) < 3e-5
     @test abs(maximum(abs, kspace) - 1) < 1e-6
     @test maximum(abs, kspace - X) / maximum(abs, kspace) < 2e-3
@@ -139,22 +120,6 @@ end
 
     kx, ky = (fr * cos(ϕ[ia]), fr * sin(ϕ[ia])) # Fourier-slice theorem
     ideal = spectrum(ob).(kx, ky)
-
-if DEBUG
-    @show maximum(abs, ideal - Slice) / maximum(abs, ideal)
-    p2 = jim(r, rad2deg.(ϕ), sino; aspect_ratio=:none, title="sinogram")
-    jim(p1, p2)
-    p3 = plot(r, slice, title="profile at ϕ = $angle", label="")
-    p4 = scatter(fr, abs.(Slice), label="abs fft", color=:blue)
-    scatter!(fr, real(Slice), label="real fft", color=:green)
-    scatter!(fr, imag(Slice), label="imag fft", color=:red,
-        xlims=(-1,1).*(0.6/m), title="1D spectra")
-
-    plot!(fr, abs.(ideal), label="abs", color=:blue)
-    plot!(fr, real(ideal), label="real", color=:green)
-    plot!(fr, imag(ideal), label="imag", color=:red)
-    plot(p1, p2, p3, p4); gui()
-end
 
     @test maximum(abs, ideal - Slice) / maximum(abs, ideal) < 5e-6
 end


### PR DESCRIPTION
Handy for Radon transform sanity checks...
Also eliminate Vector{Number} approach because it does not allow type inference and is not needed because of splatting.
And remove old DEBUG code.