### PR TITLE
Use `Pkg.add` in notebooks

### DIFF
--- a/docs/lit/examples/01-overview.jl
+++ b/docs/lit/examples/01-overview.jl
@@ -25,6 +25,9 @@ This page was generated from a single Julia file:
 
 # Packages needed here.
 
+#nb import Pkg
+#nb Pkg.add(["ImageGeoms", "MIRTjim", "UnitfulRecipes", "Unitful"])
+
 using ImagePhantoms
 using ImageGeoms: ImageGeom, axesf
 using MIRTjim: jim, prompt


### PR DESCRIPTION
Binder seemed to not have a version of `ImageGeoms` and had an old version of `ImagePhantoms`.
Perhaps using `Pkg.add` would help?  This is a little experiment to find out.