### PR TITLE
Add 3D Shepp-Logan phantom, and iterable collection for `radon`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ImagePhantoms"
 uuid = "71a99df6-f52c-4da1-bd2a-69d6f37f3252"
 authors = ["Jeff Fessler <fessler@umich.edu> and contributors"]
-version = "0.5.0"
+version = "0.6.0"
 
 [deps]
 LazyGrids = "7031d0ef-c40d-4431-b2f8-61a8d2f650db"

--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ https://github.com/JuliaImageRecon/ImagePhantoms.jl
 
 This Julia language repo
 provides tools for working with software-defined image phantoms
-like the Shepp-Logan phantom.
+like the Shepp-Logan phantom
+(both 2D and 3D versions).
 
 
 For each phantom shape,

--- a/docs/lit/examples/07-shepp.jl
+++ b/docs/lit/examples/07-shepp.jl
@@ -28,7 +28,6 @@ This page was generated from a single Julia file:
 using ImagePhantoms: shepp_logan, SouthPark
 using ImagePhantoms: SheppLoganToft, SheppLoganEmis, SheppLoganBrainWeb
 using ImagePhantoms: ellipse_parameters, ellipse, phantom
-using ImageGeoms: ImageGeom, axesf
 using MIRTjim: jim, prompt
 using Unitful: g, cm
 

--- a/docs/lit/examples/37-shepp3.jl
+++ b/docs/lit/examples/37-shepp3.jl
@@ -1,0 +1,76 @@
+#---------------------------------------------------------
+# # [3D Shepp-Logan Phantom](@id 37-shepp3)
+#---------------------------------------------------------
+
+#=
+This page illustrates the Shepp-Logan phantoms in the Julia package
+[`ImagePhantoms`](https://github.com/JuliaImageRecon/ImagePhantoms.jl).
+
+This page was generated from a single Julia file:
+[37-shepp3.jl](@__REPO_ROOT_URL__/37-shepp3.jl).
+=#
+
+#md # In any such Julia documentation,
+#md # you can access the source code
+#md # using the "Edit on GitHub" link in the top right.
+
+#md # The corresponding notebook can be viewed in
+#md # [nbviewer](http://nbviewer.jupyter.org/) here:
+#md # [`37-shepp3.ipynb`](@__NBVIEWER_ROOT_URL__/37-shepp3.ipynb),
+#md # and opened in [binder](https://mybinder.org/) here:
+#md # [`37-shepp3.ipynb`](@__BINDER_ROOT_URL__/37-shepp3.ipynb).
+
+
+# ### Setup
+
+# Packages needed here.
+
+using ImagePhantoms: ellipsoid_parameters, ellipsoid, phantom
+using ImageGeoms: ImageGeom, axes
+using MIRTjim: jim, prompt
+using Unitful: g, cm
+
+
+# The following line is helpful when running this file as a script;
+# it prompts user to hit a key after each figure is displayed.
+
+isinteractive() ? jim(:prompt, true) : prompt(:draw);
+
+
+#=
+### Overview
+
+Currently this package provides
+one version of a 3D Shepp-Logan phantom
+consisting of ellipsoids.
+
+For completeness,
+we illustrate it using units,
+though units are not required.
+
+We use cm for the spatial units
+and g/cm³ (density)
+for the tissue values.
+=#
+
+fovs = (24cm, 24cm, 20cm)
+u = (1, 1, 1*g/cm^3)
+params = ellipsoid_parameters( ; fovs, u)
+ob = ellipsoid(params); # Vector of Ellipsoid objects
+
+
+#=
+To visualize this phantom,
+we sample it
+with the help of `ImageGeoms`,
+using over-sampling
+to account for partial volume effects.
+=#
+
+dims = (128,130,30)
+ig = ImageGeom( ; dims, deltas = fovs ./ dims )
+
+oversample = 3
+image = phantom(axes(ig)..., ob, oversample)
+clim = (0.95, 1.05)
+jim(axes(ig)[1:2]..., image; title = "3D Shepp-Logan phantom slices", clim)

--- a/src/object.jl
+++ b/src/object.jl
@@ -241,3 +241,19 @@ Ensures that its precision is at least `Float32`.
 function radon_type(::Object{S, D, V, C, A}) where {S, D, V <: Number, C <: RealU, A <: RealU}
     return eltype(oneunit(C) * oneunit(V) * one(A) * 1f0) # at least Float32
 end
+
+
+"""
+    radon(itr, oa::Array{<:Object})
+Return parallel-beam projections
+sampled at locations
+returned by generator (or iterator) `itr`.
+Returned array size matches `size(itr)`.
+"""
+function radon(
+    itr,
+    oa::Array{<:Object},
+)
+    fun = radon(oa)
+    return [fun(i...) for i in itr]
+end

--- a/src/object.jl
+++ b/src/object.jl
@@ -132,7 +132,7 @@ function Object(
     wy::RealU = wx,
     ϕ::RealU = 0,
     value::Number = 1,
-) where {C <: RealU}
+)
     Object(shape, (cx, cy), (wx, wy), (ϕ,), value)
 end
 
@@ -152,7 +152,7 @@ function Object(
     ϕ::RealU = 0,
     θ::RealU = 0,
     value::Number = 1,
-) where {C <: RealU}
+)
     Object(shape, (cx, cy, cz), (wx, wy, wz), (ϕ, θ), value)
 end
 

--- a/src/shepplogan.jl
+++ b/src/shepplogan.jl
@@ -309,9 +309,9 @@ who said that the Kak&Slaney 1988 values are incorrect.
         0.06    -0.105  0.0625  0.056   0.04    0.1     -90     0.02;
         0       0.1     0.625   0.056   0.056   0.1     0       -0.02
     ]
-    params[:,1:6] ./= 2
-    params[:,7] .*= π/180
-    out = [params[:,1:7] zeros(size(params,1)) params[:,8]] # add Θ=0
+    params[:,1:6] ./= 2 # radii
+    params[:,7] .*= π/180 # radians
+    out = [params[:,1:7] zeros(size(params,1)) params[:,8]] # Θ=0
     return out
 end
 
@@ -390,9 +390,7 @@ function ellipsoid_parameters(
     u::NTuple{3,Number} = (1,1,1), # unit scaling
 )
 
-    params = ellipsoid_parameters_shepplogan()
-    params[:,1:6] ./= 2
-    params[:,7:8] .*= π/180
+    params = ellipsoid_parameters_shepplogan() # (N,9)
 
     case == SheppLogan3() || throw("unsupported")
 #   params[:,9] = shepp_logan_values(case)

--- a/test/iter.jl
+++ b/test/iter.jl
@@ -1,0 +1,32 @@
+# test/iter.jl
+
+using ImagePhantoms: radon, rect, cuboid
+using Unitful: m
+using Test: @test, @testset, @inferred
+
+@testset "iter2" begin
+    ob = rect((4m, 3m), (2m, 5m), π/6, 1.0f0)
+    nr, dr = 2^4, 0.02m
+    r = (-nr÷2:nr÷2-1) * dr
+    ϕ = deg2rad.(0:30:360)
+#   ϕ = 0:30:360 # todo inference
+    sino1 = @inferred radon(r, ϕ, [ob])
+    itr = Iterators.product(r, ϕ)
+    sino2 = @inferred radon(itr, [ob])
+    @test sino1 == sino2
+end
+
+@testset "iter3" begin
+    ob = cuboid((1m, 2m, 3m), (4m, 5m, 6m), (π/6, 0), 1.0f0)
+    nu, du = 2^4, 0.02m
+    nv, dv = 2^3, 0.03m
+    u = (-nu÷2:nu÷2-1) * du
+    v = (-nv÷2:nv÷2-1) * dv
+    ϕ = deg2rad.(0:30:360)
+    θ = deg2rad.([0, 10])
+#   ϕ = 0:30:360 # todo inference
+    proj1 = @inferred radon(u, v, ϕ, θ, [ob])
+    itr = Iterators.product(u, v, ϕ, θ)
+    proj2 = @inferred radon(itr, [ob])
+    @test proj1 == proj2
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -14,6 +14,8 @@ include("focus-chart.jl")
 
 include("shape3.jl")
 
+include("iter.jl")
+
 @testset "mri-sense" begin
     include("mri-sense.jl")
 end

--- a/test/shepplogan.jl
+++ b/test/shepplogan.jl
@@ -2,6 +2,7 @@
 
 using ImagePhantoms # many
 import ImagePhantoms as IP
+using Unitful: cm
 using Test: @test, @testset, @inferred
 
 
@@ -52,4 +53,15 @@ using Test: @test, @testset, @inferred
     @test kspace isa Matrix
 
     image = @inferred shepp_logan(M, N, SouthPark(), fovs=(1,1))
+end
+
+
+@testset "shepp3" begin
+    @test (@inferred ellipsoid_parameters()) isa Vector{<:Tuple}
+    fovs = (8,9,3) .* 1cm
+    @inferred ellipsoid_parameters( ; fovs)
+    u = (1cm,1,1/cm)
+    @inferred ellipsoid_parameters( ; u)
+    u = (1,1,1/cm)
+    @inferred ellipsoid_parameters( ; fovs, u)
 end


### PR DESCRIPTION
The iterable collection facilitates `rays` in Sinograms.jl.