### PR TITLE
Introduce third rotation angle for 3D objects

### DIFF
--- a/docs/lit/examples/01-overview.jl
+++ b/docs/lit/examples/01-overview.jl
@@ -179,23 +179,43 @@ jim(p0, p1)
 For a 3D object,
 there are three rotation angles,
 often called
-[Euler_angles](https://en.wikipedia.org/wiki/Euler_angles),
+[Euler angles](https://en.wikipedia.org/wiki/Euler_angles),
 and there are many possible conventions
 for the names and ordering of these angles.
 
 This package denotes
-the three angles as ``ϕ,θ,ψ,``
-where,
-for consistency with the 2D case,
+the three angles as ``ϕ,θ,ψ.``
+
+### Rotation about ``z`` by ``ϕ``
+
+For consistency with the 2D case,
 the first of the three angles,
 ``ϕ``,
 denotes rotation in the ``(x,y)`` plane,
 i.e., around the ``z``-axis.
-
 In
-[wikipedia notation](https://en.wikipedia.org/w/index.php?title=Rotation_matrix&section=9#In_three_dimensions)
+[wikipedia's notation](https://en.wikipedia.org/w/index.php?title=Rotation_matrix&section=9#In_three_dimensions)
 this is
-``R_z(ϕ)``.
+``R_z(ϕ)``,
+defined as
+```math
+\left[ \begin{matrix}
+x' \\ y' \\ z'
+\end{matrix} \right]
+=
+\left[ \begin{matrix}
+\cos(θ) & -\sin(θ) & 0
+\\
+\sin(θ) & \cos(θ) & 0
+\\
+0 & 0 & 1
+\\
+\end{matrix} \right]
+\left[ \begin{matrix}
+x \\ y \\ z
+\end{matrix} \right]
+```
+as illustrated by the blue star below.
 
 Here is an illustration
 for $ϕ = π/6$.
@@ -227,6 +247,8 @@ jim(p0z, p1z)
 
 
 #=
+### Rotation about ``y`` by ``θ``
+
 The 2nd of the three angles,
 ``θ``,
 corresponds to rotation around the ``y``-axis,
@@ -288,6 +310,8 @@ jim(p0y, p1y)
 
 
 #=
+### Rotation about ``x`` by ``ψ``
+
 The 3rd of the three angles,
 ``ψ``,
 corresponds to rotation around the ``x``-axis:
@@ -298,9 +322,9 @@ x' \\ y' \\ z'
 \end{matrix} \right]
 =
 \left[ \begin{matrix}
-0 & \cos(ψ) & -\sin(ψ)
-\\
 1 & 0 & 0
+\\
+0 & \cos(ψ) & -\sin(ψ)
 \\
 0 & \sin(ψ) & \cos(ψ)
 \\
@@ -347,7 +371,7 @@ jim(p0x, p1x)
 
 
 #src # Summarizing all in one plot:
-jim(p0x, p0y, p0z, p1x, p1y, p1z)
+#src jim(p0x, p0y, p0z, p1x, p1y, p1z)
 
 
 #=

--- a/docs/lit/examples/01-overview.jl
+++ b/docs/lit/examples/01-overview.jl
@@ -378,8 +378,67 @@ jim(p0x, p1x)
 The remaining issue is the multiplication order
 for multiple rotations.
 
+To address that,
+we first describe
+how phantoms are generated in this package.
+Every phantom shape
+starts with a base function
+that is translated, rotated, and scaled
+to make the final object.
+For example,
+an ellipsoid is a transformed sphere.
+Specifically,
+if ``e(r)`` is the ellipsoid function,
+and ``s(r)`` is the unit sphere function,
+where
+``r = (x,y,z)``,
+then
+```math
+e(r) = s( (R_{xyz}^T (r - c)) ⊘ w )
+```
+where ``c`` is the `center` of the ellipsoid,
+and ``r`` is the `width` parameter (actually radii),
+``⊘`` denotes element-wise division,
+and ``R_{xyz}^T``
+is the *inverse*
+of the 3D rotation matrix
+``R_{xyz}``
+defined by
+``R_{xyz} = R_x(ψ) R_y(θ) R_z(ϕ)``.
+
+Note that ``r`` and ``c`` and ``w``
+all must have identical units
+and the argument
+``(R_{xyz}^T (r - c)) ⊘ w``
+passed the unit sphere function
+is unitless,
+as it must be.
+The non-exported `phantom1` function
+for each shape
+defines the base shape function.
+For the unit sphere it is simply
+`sum(abs2, r) ≤ 1`.
+
+Rearranging the equation
+``r' = (R_{xyz}^T (r - c)) ⊘ w``
+yields
+``r = R_{xyz} (w ⊙ r') + c``
+so the process of transforming a unit sphere
+to an ellipsoid starts with scaling,
+then rotation by
+``R_{xyz}``,
+which rotates first around the ``z``-axis,
+and then finally translating.
+
+todo: need some illustration
+
+The `spectrum` method
+accounts for the translation, rotation, and scaling
+of the base shape function
+using elementary Fourier transform properties.
+
+todo: check with full 3D rotation!
 =#
-# todo discuss order
 
 
 # ## Reproducibility

--- a/docs/lit/examples/32-ellipsoid.jl
+++ b/docs/lit/examples/32-ellipsoid.jl
@@ -62,9 +62,9 @@ center = (20mm, 10mm, 5mm)
 radii = (25mm, 35mm, 15mm)
 ϕ0s = :(π/6) # symbol version for nice plot titles
 ϕ0 = eval(ϕ0s)
-angles = (ϕ0, 0)
+angles = (ϕ0, 0, 0)
 Object(Ellipsoid(), center, radii, angles, 1.0f0) # top-level constructor
-ellipsoid( 20mm, 10mm, 5mm, 25mm, 35mm, 15mm, π/6, 0, 1.0f0 ) # 9 arguments
+ellipsoid( 20mm, 10mm, 5mm, 25mm, 35mm, 15mm, π/6, 0, 0, 1.0f0 ) # 9 arguments
 ob = ellipsoid(center, radii, angles, 1.0f0) # tuples (recommended use)
 
 

--- a/docs/lit/examples/33-cuboid.jl
+++ b/docs/lit/examples/33-cuboid.jl
@@ -62,9 +62,9 @@ center = (10mm, 8mm, 6mm)
 width = (35mm, 25mm, 15mm)
 ϕ0s = :(π/6) # symbol version for nice plot titles
 ϕ0 = eval(ϕ0s)
-angles = (ϕ0, 0)
+angles = (ϕ0, 0, 0)
 Object(Cuboid(), center, width, angles, 1.0f0) # top-level constructor
-cuboid( 10mm, 8mm, 6mm, 35mm, 25mm, 15mm, π/6, 0, 1.0f0 ) # 9 arguments
+cuboid( 10mm, 8mm, 6mm, 35mm, 25mm, 15mm, π/6, 0, 0, 1.0f0 ) # 9 arguments
 ob = cuboid(center, width, angles, 1.0f0) # tuples (recommended use)
 
 

--- a/docs/lit/examples/34-gauss3.jl
+++ b/docs/lit/examples/34-gauss3.jl
@@ -63,9 +63,9 @@ center = (20mm, 10mm, 5mm)
 width = (25mm, 35mm, 15mm)
 ϕ0s = :(π/6) # symbol version for nice plot titles
 ϕ0 = eval(ϕ0s)
-angles = (ϕ0, 0)
+angles = (ϕ0, 0, 0)
 Object(Gauss3(), center, width, angles, 1.0f0) # top-level constructor
-gauss3(20mm, 10mm, 5mm, 25mm, 35mm, 15mm, π/6, 0, 1.0f0) # 9 arguments
+gauss3(20mm, 10mm, 5mm, 25mm, 35mm, 15mm, π/6, 0, 0, 1.0f0) # 9 arguments
 ob = gauss3(center, width, angles, 1.0f0) # tuples (recommended use)
 
 

--- a/docs/lit/examples/35-cylinder.jl
+++ b/docs/lit/examples/35-cylinder.jl
@@ -62,9 +62,9 @@ center = (20mm, 10mm, 5mm)
 width = (25mm, 35mm, 15mm) # x radius, y radius, height
 ϕ0s = :(π/6) # symbol version for nice plot titles
 ϕ0 = eval(ϕ0s)
-angles = (ϕ0, 0)
+angles = (ϕ0, 0, 0)
 Object(Cylinder(), center, width, angles, 1.0f0) # top-level constructor
-cylinder( 20mm, 10mm, 5mm, 25mm, 35mm, 15mm, π/6, 0, 1.0f0) # 9 arguments
+cylinder( 20mm, 10mm, 5mm, 25mm, 35mm, 15mm, π/6, 0, 0, 1.0f0) # 9 arguments
 ob = cylinder(center, width, angles, 1.0f0) # tuples (recommended use)
 
 

--- a/src/ImagePhantoms.jl
+++ b/src/ImagePhantoms.jl
@@ -4,6 +4,7 @@ const RealU = Number # Union{Real, Unitful.Length}
 
 # core:
 include("shape.jl")
+include("rotate3.jl")
 include("object.jl")
 include("object2.jl")
 include("object3.jl")

--- a/src/cuboid.jl
+++ b/src/cuboid.jl
@@ -18,7 +18,7 @@ struct Cuboid <: AbstractShape{3} end
 
 """
     cuboid(cx, cy, cz, wx, wy, wz, Φ, Θ, value::Number)
-    cuboid(center::NTuple{3,RealU}, width::NTuple{3,RealU}, angle::NTuple{2,RealU}, v)
+    cuboid(center::NTuple{3,RealU}, width::NTuple{3,RealU}, angle::NTuple{3,RealU}, v)
 Construct `Object{Cuboid}` from parameters;
 here `width` is the full-width.
 """

--- a/src/cylinder.jl
+++ b/src/cylinder.jl
@@ -17,7 +17,7 @@ struct Cylinder <: AbstractShape{3} end
 
 """
     cylinder(cx, cy, cz, wx, wy, wz, Φ, Θ, value::Number)
-    cylinder(center::NTuple{3,RealU}, width::NTuple{3,RealU}, angle::NTuple{2,RealU}, v)
+    cylinder(center::NTuple{3,RealU}, width::NTuple{3,RealU}, angle::NTuple{3,RealU}, v)
 Construct `Object{Cylinder}` from parameters;
 here `width` is the *radius* in x,y and the *height* in z.
 """

--- a/src/cylinder.jl
+++ b/src/cylinder.jl
@@ -49,19 +49,19 @@ phantom1(ob::Object3d{Cylinder}, xyz::NTuple{3,Real}) =
 # line integral through rectangle of width (wx,wy) at (r,ϕ)
 function _rect_proj(wx::Real, wy::Real, r::Real, ϕ::Real)
     (sϕ, cϕ) = sincos(ϕ)
-	rp = sqrt((wx * cϕ)^2 + (wy * sϕ)^2) # projected radius
-	dis = r / rp # scaled distance from center
-	abs_cos_ang_pi = wx * abs(cϕ) / rp
-	abs_sin_ang_pi = wy * abs(sϕ) / rp
+    rp = sqrt((wx * cϕ)^2 + (wy * sϕ)^2) # projected radius
+    dis = r / rp # scaled distance from center
+    abs_cos_ang_pi = wx * abs(cϕ) / rp
+    abs_sin_ang_pi = wy * abs(sϕ) / rp
 
-	# break points of the trapezoid
-	len = 1 / max(abs_cos_ang_pi, abs_sin_ang_pi)
-	dmax = (abs_cos_ang_pi + abs_sin_ang_pi) / 2
-	dbreak = abs(abs_cos_ang_pi - abs_sin_ang_pi) / 2
-	dmax_break = dmax - dbreak
-	scale = wx * wy / rp * len #lmax
+    # break points of the trapezoid
+    len = 1 / max(abs_cos_ang_pi, abs_sin_ang_pi)
+    dmax = (abs_cos_ang_pi + abs_sin_ang_pi) / 2
+    dbreak = abs(abs_cos_ang_pi - abs_sin_ang_pi) / 2
+    dmax_break = dmax - dbreak
+    scale = wx * wy / rp * len #lmax
 
-	return scale * trapezoid(dis, -dmax, -dbreak, dbreak, dmax)
+    return scale * trapezoid(dis, -dmax, -dbreak, dbreak, dmax)
 end
 
 

--- a/src/ellipsoid.jl
+++ b/src/ellipsoid.jl
@@ -16,7 +16,7 @@ struct Ellipsoid <: AbstractShape{3} end
 
 """
     ellipsoid(cx, cy, cz, rx=1, ry=1, rz=1, Φ=0, Θ=0, value::Number = 1)
-    ellipsoid(center::NTuple{3,RealU}, radii::NTuple{3,RealU}, angle::NTuple{2,RealU}, v)
+    ellipsoid(center::NTuple{3,RealU}, radii::NTuple{3,RealU}, angle::NTuple{3,RealU}, v)
 Construct `Object{Ellipsoid}` from parameters.
 """
 ellipsoid(args... ; kwargs...) = Object(Ellipsoid(), args...; kwargs...)

--- a/src/object.jl
+++ b/src/object.jl
@@ -31,14 +31,14 @@ General container for 2D and 3D objects for defining image phantoms.
 
 ```jldoctest
 julia> Object(Ellipse(), (0,0), (1,2), 0.0, 1//2)
-Object2d{Ellipse, Rational{Int64}, Int64, Float64, 1} (S, D, V, ...)
+Object2d{Ellipse, Rational{Int64}, Int64, Float64, 1, Float64} (S, D, V, ...)
  center::NTuple{2,Int64} (0, 0)
  width::NTuple{2,Int64} (1, 2)
  angle::Tuple{Float64} (0.0,)
  value::Rational{Int64} 1//2
 ```
 """
-struct Object{S, D, V, C, A, Da} <: AbstractObject
+struct Object{S, D, V, C, A, Da, T} <: AbstractObject
     "x,y center coordinates"
     center::NTuple{D,C}
     "'width' along x',y' axes (FWHM for Gauss, radii for Ellipse)"
@@ -48,8 +48,8 @@ struct Object{S, D, V, C, A, Da} <: AbstractObject
     "'intensity' value for this shape"
     value::V
 
-    sin::NTuple{Da,A} # sin.(angle) todo
-    cos::NTuple{Da,A} # cos.(angle)
+    sin::NTuple{Da,T} # sin.(angle)
+    cos::NTuple{Da,T} # cos.(angle)
 
     """
         Object{S}(center, width, angle, value)
@@ -73,7 +73,9 @@ struct Object{S, D, V, C, A, Da} <: AbstractObject
         C = promote_type(eltype.(center)..., eltype.(width)...)
         angle = promote((1f0 .* angle)...) # ensure at least Float32
         A = eltype(angle)
-        new{S,D,V,C,A,Da}(C.(center), C.(width), angle, value, sin.(angle), cos.(angle))
+        T = eltype(one(A))
+        new{S,D,V,C,A,Da,T}(C.(center), C.(width), angle, value,
+            T.(sin.(angle)), T.(cos.(angle)))
     end
 end
 

--- a/src/object.jl
+++ b/src/object.jl
@@ -252,6 +252,22 @@ end
 
 
 """
+    phantom(itr, oa::Array{<:Object})
+Return phantom values
+sampled at locations
+returned by generator (or iterator) `itr`.
+Returned array size matches `size(itr)`.
+"""
+function phantom(
+    itr,
+    oa::Array{<:Object},
+)
+    fun = phantom(oa)
+    return [fun(i...) for i in itr]
+end
+
+
+"""
     radon(itr, oa::Array{<:Object})
 Return parallel-beam projections
 sampled at locations
@@ -263,5 +279,21 @@ function radon(
     oa::Array{<:Object},
 )
     fun = radon(oa)
+    return [fun(i...) for i in itr]
+end
+
+
+"""
+    spectrum(itr, oa::Array{<:Object})
+Return spectrum of object(s)
+sampled at k-space locations
+returned by generator (or iterator) `itr`.
+Returned array size matches `size(itr)`.
+"""
+function spectrum(
+    itr,
+    oa::Array{<:Object},
+)
+    fun = spectrum(oa)
     return [fun(i...) for i in itr]
 end

--- a/src/object.jl
+++ b/src/object.jl
@@ -157,8 +157,8 @@ function Object(
     wy::RealU = wx,
     wz::RealU = wx,
     ϕ::RealU = 0,
-    θ::RealU = 0,
-    ψ::RealU = 0,
+    θ::RealU = zero(ϕ),
+    ψ::RealU = zero(ϕ),
     value::Number = 1,
 )
     Object(shape, (cx, cy, cz), (wx, wy, wz), (ϕ, θ, ψ), value)

--- a/src/object.jl
+++ b/src/object.jl
@@ -48,6 +48,9 @@ struct Object{S, D, V, C, A, Da} <: AbstractObject
     "'intensity' value for this shape"
     value::V
 
+    sin::NTuple{Da,A} # sin.(angle) todo
+    cos::NTuple{Da,A} # cos.(angle)
+
     """
         Object{S}(center, width, angle, value)
     Inner constructor for `S <: AbstractShape`.
@@ -60,15 +63,17 @@ struct Object{S, D, V, C, A, Da} <: AbstractObject
         angle::NTuple{Da,RealU},
         value::V,
     ) where {S <: AbstractShape, D, Da, V <: Number}
-        D == ndims(S()) || throw(ArgumentError("D=$D vs ndims(S)=$(ndims(S)) for S=$S"))
-        D == 2 == Da + 1 || D == Da == 3 || throw(ArgumentError("Da=$Da does not fit to D=$D"))
-
-        all(width .> zero(eltype(width))) || throw(ArgumentError("widths must be positive"))
+        D == ndims(S()) ||
+            throw(ArgumentError("D=$D vs ndims(S)=$(ndims(S)) for S=$S"))
+        D == 2 == Da + 1 || D == Da == 3 ||
+            throw(ArgumentError("Da=$Da does not fit to D=$D"))
+        all(width .> zero(eltype(width))) ||
+            throw(ArgumentError("widths must be positive"))
 
         C = promote_type(eltype.(center)..., eltype.(width)...)
-        angle = promote(angle...)
+        angle = promote((1f0 .* angle)...) # ensure at least Float32
         A = eltype(angle)
-        new{S,D,V,C,A,Da}(C.(center), C.(width), angle, value)
+        new{S,D,V,C,A,Da}(C.(center), C.(width), angle, value, sin.(angle), cos.(angle))
     end
 end
 

--- a/src/object.jl
+++ b/src/object.jl
@@ -61,7 +61,7 @@ struct Object{S, D, V, C, A, Da} <: AbstractObject
         value::V,
     ) where {S <: AbstractShape, D, Da, V <: Number}
         D == ndims(S()) || throw(ArgumentError("D=$D vs ndims(S)=$(ndims(S)) for S=$S"))
-        1 ≤ Da == D-1 || throw(ArgumentError("Da=$Da != D-1, where D=$D"))
+        D == 2 == Da + 1 || D == Da == 3 || throw(ArgumentError("Da=$Da does not fit to D=$D"))
 
         all(width .> zero(eltype(width))) || throw(ArgumentError("widths must be positive"))
 
@@ -109,13 +109,13 @@ function Object(
     shape::AbstractShape{D},
     _center::NTuple{D,RealU} = _tuple(0, D),
     _width::NTuple{D,RealU} = _tuple(1, D),
-    _angle::Union{RealU, NTuple{Da,RealU}} where Da = _tuple(0, D-1),
+    _angle::Union{RealU, NTuple{Da,RealU}} = _tuple(0, D == 2 ? 1 : 3),
     _value::Number = 1f0 ;
     center::NTuple{D,RealU} = _center,
     width::NTuple{D,RealU} = _width,
-    angle::Union{RealU, NTuple{Da,RealU}} where Da = _angle,
+    angle::Union{RealU, NTuple{Da,RealU}} = _angle,
     value::Number = _value,
-) where {D}
+) where {D,Da}
     Object{typeof(shape)}(center, width, angle, value)
 end
 
@@ -138,7 +138,7 @@ end
 
 
 """
-    Object(shape ; cx, cy, cz, wx=1, wy=wx, wz=wx, ϕ=0, θ=0, value=1)
+    Object(shape ; cx, cy, cz, wx=1, wy=wx, wz=wx, ϕ=0, θ=0, ψ=0, value=1)
 3D object constructor from values (without tuples).
 """
 function Object(
@@ -151,9 +151,10 @@ function Object(
     wz::RealU = wx,
     ϕ::RealU = 0,
     θ::RealU = 0,
+    ψ::RealU = 0,
     value::Number = 1,
 )
-    Object(shape, (cx, cy, cz), (wx, wy, wz), (ϕ, θ), value)
+    Object(shape, (cx, cy, cz), (wx, wy, wz), (ϕ, θ, ψ), value)
 end
 
 

--- a/src/object2.jl
+++ b/src/object2.jl
@@ -27,7 +27,8 @@ rotate(ob::Object2d{S}, θ::RealU) where S =
 Put coordinates `(x,y)` in canonical axes associated with `object`.
 """
 function coords(ob::Object2d, x::RealU, y::RealU)
-    xy = rotate2d(x - ob.center[1], y - ob.center[2], ob.angle[1])
+#   xy = rotate2d(x - ob.center[1], y - ob.center[2], ob.angle[1])
+    xy = rotate2d(x - ob.center[1], y - ob.center[2], ob.sin[1], ob.cos[1])
     return xy ./ ob.width # unitless
 end
 
@@ -223,8 +224,9 @@ end
 
 
 # apply rotate, translate, and scale properties of 2D Fourier transform
-function _spectrum(ob::Object2d, fx, fy, cx, cy, rx, ry, Φ)
-    (kx, ky) = rotate2d(fx, fy, Φ) # rotate then translate
+function _spectrum(ob::Object2d, fx, fy, cx, cy, rx, ry) #, Φ)
+    # rotate then translate:
+    (kx, ky) = rotate2d(fx, fy, ob.sin[1], ob.cos[1])
     return rx * ry * cispi(-2*(fx*cx + fy*cy)) *
         spectrum1(ob, (rx*kx, ry*ky))
 end
@@ -241,7 +243,7 @@ of the units defining the object.
 """
 function spectrum(ob::Object2d)
     return (fx,fy) -> ob.value *
-        _spectrum(ob, fx, fy, ob.center..., ob.width..., ob.angle[1])
+        _spectrum(ob, fx, fy, ob.center..., ob.width...) #, ob.angle[1])
 end
 
 
@@ -274,10 +276,9 @@ end
 
 # helper
 
-
-function rotate2d(x::RealU, y::RealU, θ::RealU)
-    (s, c) = sincos(θ)
-    return (c * x + s * y, -s * x + c * y)
+function rotate2d(x::RealU, y::RealU, sinθ::Real, cosθ::Real)
+    return (cosθ * x + sinθ * y, -sinθ * x + cosθ * y)
 end
 
-rotate2d(xy::NTuple{2,RealU}, θ::RealU) = rotate2d(xy..., θ)
+rotate2d(x::RealU, y::RealU, θ::RealU) = rotate2d(x, y, sincos(θ)...)
+rotate2d(xy::NTuple{2,RealU}, args...) = rotate2d(xy..., args...)

--- a/src/object3.jl
+++ b/src/object3.jl
@@ -126,10 +126,12 @@ end
 # rotation property (only axial for now)
 function xray_rotate(
     Δu::RealU, Δv::RealU, ϕ::RealU, θ::RealU, # projection coordinates
-    Φazim::RealU,
+    Φazim::RealU, # object angles
     Θpolar::RealU,
+    ψ::RealU,
 )
-    Θpolar == zero(Θpolar) || throw("nonzero polar object angle not done")
+    iszero(Θpolar) || throw("nonzero polar object angle not done")
+    iszero(ψ) || throw("nonzero ψ object angle not done for radon") # todo
     return (Δu, Δv, ϕ - Φazim, θ)
 end
 
@@ -162,9 +164,9 @@ end
 # interface to xray1 after applying shift, rotate, scale properties
 function _xray(
     type::AbstractShape{3},
-    center::Tuple,
-    width::Tuple,
-    angle::Tuple,
+    center::NTuple{3,RealU},
+    width::NTuple{3,RealU},
+    angle::NTuple{3,RealU},
     u::RealU, v::RealU, ϕ::RealU, θ::RealU,
 )
     Δu, Δv, ϕ, θ = xray_shift(u, v, ϕ, θ, center...)
@@ -177,7 +179,7 @@ end
 # this gateway seems to help type inference
 function _radon(ob::Object3d{S}, u::RealU, v::RealU, ϕ::RealU, θ::RealU) where S
     T = radon_type(ob)
-    return T(ob.value * _xray(S(), ob.center, ob.width, ob.angle[1:2], u, v, ϕ, θ))::T
+    return T(ob.value * _xray(S(), ob.center, ob.width, ob.angle, u, v, ϕ, θ))::T
 end
 
 

--- a/src/object3.jl
+++ b/src/object3.jl
@@ -305,9 +305,16 @@ function rotate3d(x::RealU, y::RealU, z::RealU, ϕ::RealU, θ::RealU, ψ::RealU)
     sinθ, cosθ = sincos(θ)
     sinψ, cosψ = sincos(-ϕ)
 
-    return (cosθ*cosψ*x + cosθ*-sinψ*y + sinθ*z,
-           (sinϕ*sinθ*cosψ + cosϕ*sinψ)*x + (sinϕ*sinθ*-sinψ + cosϕ*cosψ)*y + -sinϕ*cosθ*z,
-           (cosϕ*-sinθ*cosψ + sinϕ*sinψ)*x + (cosϕ*sinθ*sinψ + sinϕ*cosψ)*y + cosϕ*cosθ*z)    
+    return (
+        cosθ * cosψ * x + cosθ * -sinψ * y + sinθ * z,
+        (sinϕ * sinθ * cosψ + cosϕ * sinψ) * x +
+        (sinϕ * sinθ * -sinψ + cosϕ * cosψ) * y +
+        -sinϕ * cosθ * z,
+        (cosϕ * -sinθ * cosψ + sinϕ * sinψ) * x +
+        (cosϕ * sinθ * sinψ + sinϕ * cosψ) * y +
+        cosϕ * cosθ * z,
+    )
 end
 
-rotate3d(xyz::NTuple{3,RealU}, ϕ::RealU, θ::RealU, ψ::RealU) = rotate3d(xyz..., ϕ, θ, ψ)
+rotate3d(xyz::NTuple{3,RealU}, ϕ::RealU, θ::RealU, ψ::RealU) =
+    rotate3d(xyz..., ϕ, θ, ψ)

--- a/src/object3.jl
+++ b/src/object3.jl
@@ -29,7 +29,10 @@ rotate(ob::Object3d, α::RealU, β::RealU=0, γ::RealU=0) = rotate(ob, (α,β,γ
 Put coordinates `(x,y,z)` in canonical axes associated with `object`.
 """
 function coords(ob::Object3d, x::RealU, y::RealU, z::RealU)
-    xyz = rotate3d(x - ob.center[1], y - ob.center[2], z - ob.center[3],
+# todo
+#   xyz = rotate3d(x - ob.center[1], y - ob.center[2], z - ob.center[3],
+#       -ob.angle[1], -ob.angle[2], -ob.angle[3])
+    xyz = Rxyz_transpose(x - ob.center[1], y - ob.center[2], z - ob.center[3],
         ob.angle[1], ob.angle[2], ob.angle[3])
     return xyz ./ ob.width # unitless
 end
@@ -300,6 +303,67 @@ end
 # helper
 
 
+"""
+    Rxyz(x::RealU, y::RealU, z::RealU, ϕ::RealU, θ::RealU, ψ::RealU)
+    Rxyz(x::RealU, y::RealU, sinϕ, sinθ, sinψ, cosϕ, cosθ, cosψ)
+Multiply `Rx(ψ) * Ry(θ) * Rz(ϕ) * [x, y, z]` for 3D rotation.
+"""
+function Rxyz(x::RealU, y::RealU, z::RealU,
+    sinϕ::Real, sinθ::Real, sinψ::Real,
+    cosϕ::Real, cosθ::Real, cosψ::Real,
+)
+    return (
+        cosθ * x +
+         sinθ * sinϕ * y +
+         sinθ * cosϕ * z,
+        (sinψ * sinθ) * x +
+         (cosψ * cosϕ - sinψ * cosθ * sinϕ) * y +
+         (cosψ * - sinϕ) * z,
+        (cosψ * -sinθ) * x +
+         (sinψ * cosϕ - sinψ * cosθ * sinϕ) * y +
+         (sinψ * -sinϕ + cosψ * cosθ * cosϕ) * z
+    )
+end
+
+function Rxyz(x::RealU, y::RealU, z::RealU, ϕ::RealU, θ::RealU, ψ::RealU)
+    sinϕ, cosϕ = sincos(ϕ)
+    sinθ, cosθ = sincos(θ)
+    sinψ, cosψ = sincos(ψ)
+    return Rxyz(x, y, z, sinϕ, sinθ, sinψ, cosϕ, cosθ, cosψ)
+end
+
+
+"""
+    Rxyz_transpose(x::RealU, y::RealU, z::RealU, ϕ::RealU, θ::RealU, ψ::RealU)
+    Rxyz_transpose(x::RealU, y::RealU, sinϕ, sinθ, sinψ, cosϕ, cosθ, cosψ)
+Multiply `Rz(-ϕ) * Ry(-θ) * Rz(-ψ) * [x, y, z]` for 3D (inverse) rotation.
+"""
+function Rxyz_transpose(x::RealU, y::RealU, z::RealU,
+    sinϕ::Real, sinθ::Real, sinψ::Real,
+    cosϕ::Real, cosθ::Real, cosψ::Real,
+)
+    return (
+        cosθ * x +
+        (sinψ * sinθ) * y +
+        (cosψ * -sinθ) * z,
+         sinθ * sinϕ * x +
+         (cosψ * cosϕ - sinψ * cosθ * sinϕ) * y +
+         (sinψ * cosϕ - sinψ * cosθ * sinϕ) * z,
+         sinθ * cosϕ * x +
+         (cosψ * - sinϕ) * y +
+         (sinψ * -sinϕ + cosψ * cosθ * cosϕ) * z,
+    )
+end
+
+function Rxyz_transpose(x::RealU, y::RealU, z::RealU, ϕ::RealU, θ::RealU, ψ::RealU)
+    sinϕ, cosϕ = sincos(ϕ)
+    sinθ, cosθ = sincos(θ)
+    sinψ, cosψ = sincos(ψ)
+    return Rxyz_transpose(x, y, z, sinϕ, sinθ, sinψ, cosϕ, cosθ, cosψ)
+end
+
+
+#=
 function rotate3d(x::RealU, y::RealU, z::RealU, ϕ::RealU, θ::RealU, ψ::RealU)
     sinϕ, cosϕ = sincos(ψ)
     sinθ, cosθ = sincos(θ)
@@ -318,3 +382,4 @@ end
 
 rotate3d(xyz::NTuple{3,RealU}, ϕ::RealU, θ::RealU, ψ::RealU) =
     rotate3d(xyz..., ϕ, θ, ψ)
+=#

--- a/src/rotate3.jl
+++ b/src/rotate3.jl
@@ -9,6 +9,9 @@ rotate3.jl
     Rxyz_mul(x::RealU, y::RealU, sinϕ, sinθ, sinψ, cosϕ, cosθ, cosψ)
 Multiply `Rx(ψ) * Ry(θ) * Rz(ϕ) * [x, y, z]` for 3D rotation,
 where `ψ, θ, ϕ` denote rotation about `x, y, z` axes with right-hand rule.
+
+This is the reverse order of z-y′-x″ in
+https://en.wikipedia.org/wiki/Rotation_formalisms_in_three_dimensions#Euler_angles_(z-y%E2%80%B2-x%E2%80%B3_intrinsic)_%E2%86%92_rotation_matrix.
 """
 function Rxyz_mul(x::RealU, y::RealU, z::RealU,
     sinϕ::Real, sinθ::Real, sinψ::Real,

--- a/src/rotate3.jl
+++ b/src/rotate3.jl
@@ -75,28 +75,5 @@ end
 
 
 Rxyz_mul(xyz::NTuple{3,RealU}, args...) = Rxyz_mul(xyz..., args...)
+
 Rxyz_inv(xyz::NTuple{3,RealU}, args...) = Rxyz_inv(xyz..., args...)
-
-
-#=
-function rotate3d(x::RealU, y::RealU, z::RealU, ϕ::RealU, θ::RealU, ψ::RealU)
-    sinϕ, cosϕ = sincos(ψ)
-    sinθ, cosθ = sincos(θ)
-    sinψ, cosψ = sincos(-ϕ)
-
-    return (
-        cosθ * cosψ * x + cosθ * -sinψ * y + sinθ * z,
-
-        (sinϕ * sinθ * cosψ + cosϕ * sinψ) * x +
-        (sinϕ * sinθ * -sinψ + cosϕ * cosψ) * y +
-        -sinϕ * cosθ * z,
-
-        (cosϕ * -sinθ * cosψ + sinϕ * sinψ) * x +
-        (cosϕ * sinθ * sinψ + sinϕ * cosψ) * y +
-        cosϕ * cosθ * z,
-    )
-end
-
-rotate3d(xyz::NTuple{3,RealU}, ϕ::RealU, θ::RealU, ψ::RealU) =
-    rotate3d(xyz..., ϕ, θ, ψ)
-=#

--- a/src/rotate3.jl
+++ b/src/rotate3.jl
@@ -1,0 +1,148 @@
+#=
+rotate3.jl
+3d rotation utilities
+=#
+
+const RealU = Real
+
+
+"""
+    Rxyz_mul(x::RealU, y::RealU, z::RealU, ϕ::RealU, θ::RealU, ψ::RealU)
+    Rxyz_mul(x::RealU, y::RealU, sinϕ, sinθ, sinψ, cosϕ, cosθ, cosψ)
+Multiply `Rx(ψ) * Ry(θ) * Rz(ϕ) * [x, y, z]` for 3D rotation,
+where `ψ, θ, ϕ` denote rotation about `x, y, z` axes with right-hand rule.
+"""
+function Rxyz_mul(x::RealU, y::RealU, z::RealU,
+    sinϕ::Real, sinθ::Real, sinψ::Real,
+    cosϕ::Real, cosθ::Real, cosψ::Real,
+)
+    return (
+        cosθ * cosϕ * x +
+        cosθ * -sinϕ * y +
+        sinθ * z,
+
+        (cosψ * sinϕ + sinψ * sinθ * cosϕ) * x +
+        (cosψ * cosϕ - sinψ * sinθ * sinϕ) * y +
+        (-sinψ * cosθ) * z,
+
+        (sinψ * sinϕ - cosψ * sinθ * cosϕ) * x +
+        (sinψ * cosϕ + cosψ * sinθ * sinϕ) * y +
+        cosψ * cosθ * z,
+    )
+end
+
+
+"""
+    Rxyz_inv(x::RealU, y::RealU, z::RealU, ϕ::RealU, θ::RealU, ψ::RealU)
+    Rxyz_inv(x::RealU, y::RealU, sinϕ, sinθ, sinψ, cosϕ, cosθ, cosψ)
+Multiply `Rz(-ϕ) * Ry(-θ) * Rx(-ψ) * [x, y, z]` for 3D (inverse) rotation.
+"""
+function Rxyz_inv(x::RealU, y::RealU, z::RealU,
+    sinϕ::Real, sinθ::Real, sinψ::Real,
+    cosϕ::Real, cosθ::Real, cosψ::Real,
+)
+    return (
+        cosθ * cosϕ * x +
+        (cosψ * sinϕ + sinψ * sinθ * cosϕ) * y +
+        (sinψ * sinϕ - cosψ * sinθ * cosϕ) * z,
+
+        cosθ * -sinϕ * x +
+        (cosψ * cosϕ - sinψ * sinθ * sinϕ) * y +
+        (sinψ * cosϕ + cosψ * sinθ * sinϕ) * z,
+
+        sinθ * x +
+        (-sinψ * cosθ) * y +
+        cosψ * cosθ * z,
+    )
+end
+
+
+function Rxyz_mul(x::RealU, y::RealU, z::RealU, ϕ::RealU, θ::RealU, ψ::RealU)
+    sinϕ, cosϕ = sincos(ϕ)
+    sinθ, cosθ = sincos(θ)
+    sinψ, cosψ = sincos(ψ)
+    return Rxyz_mul(x, y, z, sinϕ, sinθ, sinψ, cosϕ, cosθ, cosψ)
+end
+
+
+function Rxyz_inv(x::RealU, y::RealU, z::RealU, ϕ::RealU, θ::RealU, ψ::RealU)
+    sinϕ, cosϕ = sincos(ϕ)
+    sinθ, cosθ = sincos(θ)
+    sinψ, cosψ = sincos(ψ)
+    return Rxyz_inv(x, y, z, sinϕ, sinθ, sinψ, cosϕ, cosθ, cosψ)
+end
+
+
+Rxyz_mul(xyz::NTuple{3,RealU}, args...) = Rxyz_mul(xyz..., args...)
+Rxyz_inv(xyz::NTuple{3,RealU}, args...) = Rxyz_inv(xyz..., args...)
+
+
+#=
+function rotate3d(x::RealU, y::RealU, z::RealU, ϕ::RealU, θ::RealU, ψ::RealU)
+    sinϕ, cosϕ = sincos(ψ)
+    sinθ, cosθ = sincos(θ)
+    sinψ, cosψ = sincos(-ϕ)
+
+    return (
+        cosθ * cosψ * x + cosθ * -sinψ * y + sinθ * z,
+
+        (sinϕ * sinθ * cosψ + cosϕ * sinψ) * x +
+        (sinϕ * sinθ * -sinψ + cosϕ * cosψ) * y +
+        -sinϕ * cosθ * z,
+
+        (cosϕ * -sinθ * cosψ + sinϕ * sinψ) * x +
+        (cosϕ * sinθ * sinψ + sinϕ * cosψ) * y +
+        cosϕ * cosθ * z,
+    )
+end
+
+rotate3d(xyz::NTuple{3,RealU}, ϕ::RealU, θ::RealU, ψ::RealU) =
+    rotate3d(xyz..., ϕ, θ, ψ)
+=#
+
+
+
+# tests
+# todo - move to test/
+
+Rx(a) = [1 0 0; 0 cos(a) -sin(a); 0 sin(a) cos(a)]
+Ry(a) = [cos(a) 0 sin(a); 0 1 0; -sin(a) 0 cos(a)]
+Rz(a) = [cos(a) -sin(a) 0; sin(a) cos(a) 0; 0 0 1]
+
+using Test
+using LinearAlgebra: I
+
+a = randn()
+@test Rx(a)' ≈ Rx(-a)
+@test Rx(a)' ≈ inv(Rx(a))
+@test Ry(a)' ≈ Ry(-a)
+@test Rz(a)' ≈ inv(Rz(a))
+@test Rz(a)' ≈ Rz(-a)
+@test Ry(a)' ≈ inv(Ry(a))
+
+function Rxyz_mat(ϕ::RealU, θ::RealU, ψ::RealU)
+    return hcat([collect(Rxyz_mul(c..., ϕ, θ, ψ)) for c in eachcol(I(3))]...)
+end
+
+function Rxyz_inv_mat(ϕ::RealU, θ::RealU, ψ::RealU)
+    return hcat([collect(Rxyz_inv(c..., ϕ, θ, ψ)) for c in eachcol(I(3))]...)
+end
+
+a = randn()
+b = randn()
+c = randn()
+
+R = Rxyz_mat(a, b, c)
+@test R' ≈ inv(R)
+
+Ri = Rxyz_inv_mat(a, b, c)
+@test Ri ≈ inv(R)
+
+R = Rxyz_mat(a, 0, 0)
+@test R ≈ Rz(a)
+
+R = Rxyz_mat(0, b, 0)
+@test R ≈ Ry(b)
+
+R = Rxyz_mat(0, 0, c)
+@test R ≈ Rx(c)

--- a/src/rotate3.jl
+++ b/src/rotate3.jl
@@ -3,8 +3,6 @@ rotate3.jl
 3d rotation utilities
 =#
 
-const RealU = Real
-
 
 """
     Rxyz_mul(x::RealU, y::RealU, z::RealU, ϕ::RealU, θ::RealU, ψ::RealU)
@@ -99,50 +97,3 @@ end
 rotate3d(xyz::NTuple{3,RealU}, ϕ::RealU, θ::RealU, ψ::RealU) =
     rotate3d(xyz..., ϕ, θ, ψ)
 =#
-
-
-
-# tests
-# todo - move to test/
-
-Rx(a) = [1 0 0; 0 cos(a) -sin(a); 0 sin(a) cos(a)]
-Ry(a) = [cos(a) 0 sin(a); 0 1 0; -sin(a) 0 cos(a)]
-Rz(a) = [cos(a) -sin(a) 0; sin(a) cos(a) 0; 0 0 1]
-
-using Test
-using LinearAlgebra: I
-
-a = randn()
-@test Rx(a)' ≈ Rx(-a)
-@test Rx(a)' ≈ inv(Rx(a))
-@test Ry(a)' ≈ Ry(-a)
-@test Rz(a)' ≈ inv(Rz(a))
-@test Rz(a)' ≈ Rz(-a)
-@test Ry(a)' ≈ inv(Ry(a))
-
-function Rxyz_mat(ϕ::RealU, θ::RealU, ψ::RealU)
-    return hcat([collect(Rxyz_mul(c..., ϕ, θ, ψ)) for c in eachcol(I(3))]...)
-end
-
-function Rxyz_inv_mat(ϕ::RealU, θ::RealU, ψ::RealU)
-    return hcat([collect(Rxyz_inv(c..., ϕ, θ, ψ)) for c in eachcol(I(3))]...)
-end
-
-a = randn()
-b = randn()
-c = randn()
-
-R = Rxyz_mat(a, b, c)
-@test R' ≈ inv(R)
-
-Ri = Rxyz_inv_mat(a, b, c)
-@test Ri ≈ inv(R)
-
-R = Rxyz_mat(a, 0, 0)
-@test R ≈ Rz(a)
-
-R = Rxyz_mat(0, b, 0)
-@test R ≈ Ry(b)
-
-R = Rxyz_mat(0, 0, c)
-@test R ≈ Rx(c)

--- a/src/shepplogan.jl
+++ b/src/shepplogan.jl
@@ -311,19 +311,19 @@ who said that the Kak&Slaney 1988 values are incorrect.
     ]
     params[:,1:6] ./= 2 # radii
     params[:,7] .*= π/180 # radians
-    out = [params[:,1:7] zeros(size(params,1)) params[:,8]] # Θ=0
+    out = [params[:,1:7] zeros(size(params,1)) zeros(size(params,1)) params[:,8]] # Θ=0, ψ=0
     return out
 end
 
 
 """
-    oa = ellipsoid(Vector{Tuple{9 params}})
+    oa = ellipsoid(Vector{Tuple{10 params}})
 Return vector of `Object{Ellipsoid}`,
 one for each element of input vector of tuples.
 Often the input comes from `ellipsoid_parameters`.
 """
 function ellipsoid(params::Vector{<:Tuple})
-    length(params[1]) == 9 || throw("ellipsoids need 9 parameters")
+    length(params[1]) == 10 || throw("ellipsoids need 10 parameters")
     out = [ellipsoid(p...) for p in params]
     return out
 end
@@ -349,9 +349,9 @@ function ellipsoid_parameters_uscale(
     C = eltype(oneunit(Tf) * oneunit(Tc) * one(Tp))
     A = eltype(oneunit(Ta) * one(Tp))
     V = eltype(oneunit(Tv) * one(Tp))
-    T = Tuple{C, C, C, C, C, C, A, A, V}
+    T = Tuple{C, C, C, C, C, C, A, A, A, V}
 
-    size(params,2) == 9 || throw(ArgumentError("params not N × 9"))
+    size(params,2) == 10 || throw(ArgumentError("params not N × 10"))
     N = size(params,1)
     out = Vector{T}(undef, N)
     for n in 1:N
@@ -359,7 +359,7 @@ function ellipsoid_parameters_uscale(
         tmp = (
             (tmp[1:3] * uc .* fovs)...,
             (tmp[4:6] * uc .* fovs)...,
-            (tmp[7:8] * ua)...,
+            (tmp[7:9] * ua)...,
             tmp[9] * uv,
         )
         out[n] = tmp

--- a/test/core.jl
+++ b/test/core.jl
@@ -28,7 +28,7 @@ using Test: @test, @testset, @inferred
     @test radon(zeros(2), zeros(3), [ob]) == 2*ones(2,3)
 
     @test spectrum([ob]) isa Function
-    @test spectrum([ob])(0,0) ≈ π
+    @test spectrum([ob])(0.,0.) ≈ π
     @test spectrum(zeros(2), zeros(3), [ob]) ≈ π*ones(2,3)
 
     @inferred IP.radon_type(ob)
@@ -38,8 +38,10 @@ end
 @testset "helpers" begin
     @test collect(@inferred IP.rotate2d(2, 1, π/2)) ≈ [1,-2]
     @test all((@inferred IP.rotate2d((2, 1), π/2)) .≈ (1,-2))
+#=
     @test ≈(collect(@inferred IP.rotate3d(2, 1, 3, π/2, 0, 0)), [1,-2,3]; atol= 1e-15)
     @test all((@inferred IP.rotate3d((2, 1, 3), π/2, 0, 0)) .≈ (1,-2, 3))
+=#
     @test (@inferred IP.coords(square(3m), 9m, 6m)) == (3, 2)
 
     @inferred IP.xray_shift(1.0f0, π/3, 3, 4//5)

--- a/test/core.jl
+++ b/test/core.jl
@@ -38,8 +38,8 @@ end
 @testset "helpers" begin
     @test collect(@inferred IP.rotate2d(2, 1, π/2)) ≈ [1,-2]
     @test all((@inferred IP.rotate2d((2, 1), π/2)) .≈ (1,-2))
-    @test ≈(collect(@inferred IP.rotate3d(2, 1, 3, π/2, 0)), [1,-2,3]; atol= 1e-15)
-    @test all((@inferred IP.rotate3d((2, 1, 3), π/2, 0)) .≈ (1,-2, 3))
+    @test ≈(collect(@inferred IP.rotate3d(2, 1, 3, π/2, 0, 0)), [1,-2,3]; atol= 1e-15)
+    @test all((@inferred IP.rotate3d((2, 1, 3), π/2, 0, 0)) .≈ (1,-2, 3))
     @test (@inferred IP.coords(square(3m), 9m, 6m)) == (3, 2)
 
     @inferred IP.xray_shift(1.0f0, π/3, 3, 4//5)

--- a/test/core.jl
+++ b/test/core.jl
@@ -38,10 +38,6 @@ end
 @testset "helpers" begin
     @test collect(@inferred IP.rotate2d(2, 1, π/2)) ≈ [1,-2]
     @test all((@inferred IP.rotate2d((2, 1), π/2)) .≈ (1,-2))
-#=
-    @test ≈(collect(@inferred IP.rotate3d(2, 1, 3, π/2, 0, 0)), [1,-2,3]; atol= 1e-15)
-    @test all((@inferred IP.rotate3d((2, 1, 3), π/2, 0, 0)) .≈ (1,-2, 3))
-=#
     @test (@inferred IP.coords(square(3m), 9m, 6m)) == (3, 2)
 
     @inferred IP.xray_shift(1.0f0, π/3, 3, 4//5)

--- a/test/iter.jl
+++ b/test/iter.jl
@@ -1,6 +1,8 @@
 # test/iter.jl
+# Test iterator versions of phantom, radon, spectrum
 
-using ImagePhantoms: radon, rect, cuboid
+using ImagePhantoms: rect, cuboid
+using ImagePhantoms: phantom, radon, spectrum
 using ImagePhantoms: _radon
 using Unitful: m
 using Test: @test, @testset, @inferred
@@ -8,14 +10,30 @@ using Test: @test, @testset, @inferred
 
 @testset "iter2" begin
     ob = rect((4m, 3m), (2m, 5m), π/6, 1.0f0 / m^2)
-    nr, dr = 2^4, 0.02m
+
+    x = LinRange(-1,6,17) * 1m
+    y = LinRange(-1,7,19) * 1m
+    p1 = @inferred phantom(x, y, [ob])
+    itr = Iterators.product(x, y)
+    p2 = @inferred phantom(itr, [ob])
+    @test p1 == p2
+
+    nr, dr = 2^4, 1m
     r = (-nr÷2:nr÷2-1) * dr
     ϕ = 0:3
     sino1 = @inferred radon(r, ϕ, [ob])
     itr = Iterators.product(r, ϕ)
     sino2 = @inferred radon(itr, [ob])
     @test sino1 == sino2
+
+    kx = LinRange(-1,1,17) / 2m
+    ky = LinRange(-1,1,19) / 3m
+    s1 = @inferred spectrum(kx, ky, [ob])
+    itr = Iterators.product(kx, ky)
+    s2 = @inferred spectrum(itr, [ob])
+    @test s1 == s2
 end
+
 
 @testset "iter3" begin
     ob = cuboid((1m, 2m, 3m), (4m, 5m, 6m), (π/6, 0, 0), 1.0f0 / m^2)

--- a/test/iter.jl
+++ b/test/iter.jl
@@ -18,7 +18,7 @@ using Test: @test, @testset, @inferred
 end
 
 @testset "iter3" begin
-    ob = cuboid((1m, 2m, 3m), (4m, 5m, 6m), (π/6, 0), 1.0f0 / m^2)
+    ob = cuboid((1m, 2m, 3m), (4m, 5m, 6m), (π/6, 0, 0), 1.0f0 / m^2)
     nu, du = 2^4, 0.02m
     nv, dv = 2^3, 0.03m
     u = (-nu÷2:nu÷2-1) * du

--- a/test/rotate3.jl
+++ b/test/rotate3.jl
@@ -1,0 +1,54 @@
+# test/rotate3.jl
+
+using ImagePhantoms: RealU, Rxyz_mul, Rxyz_inv
+using LinearAlgebra: I
+using Test: @testset, @test, @inferred
+
+
+Rx(a) = [1 0 0; 0 cos(a) -sin(a); 0 sin(a) cos(a)]
+Ry(a) = [cos(a) 0 sin(a); 0 1 0; -sin(a) 0 cos(a)]
+Rz(a) = [cos(a) -sin(a) 0; sin(a) cos(a) 0; 0 0 1]
+
+@testset "rotate" begin
+    a = randn()
+    @test Rx(a)' ≈ Rx(-a)
+    @test Rx(a)' ≈ inv(Rx(a))
+    @test Ry(a)' ≈ Ry(-a)
+    @test Rz(a)' ≈ inv(Rz(a))
+    @test Rz(a)' ≈ Rz(-a)
+    @test Ry(a)' ≈ inv(Ry(a))
+end
+
+function Rxyz_mat(ϕ::RealU, θ::RealU, ψ::RealU)
+    return hcat([collect(Rxyz_mul(c..., ϕ, θ, ψ)) for c in eachcol(I(3))]...)
+end
+
+function Rxyz_inv_mat(ϕ::RealU, θ::RealU, ψ::RealU)
+    return hcat([collect(Rxyz_inv(c..., ϕ, θ, ψ)) for c in eachcol(I(3))]...)
+end
+
+
+@testset "rotate3" begin
+    a, b, c = tuple(rand(3)...)
+    x, y, z = tuple(randn(Float32, 3)...)
+
+    @test (@inferred Rxyz_mul((x, y, z), a, b, c)) isa NTuple{3, Real}
+    @test (@inferred Rxyz_inv((x, y, z), a, b, c)) isa NTuple{3, Real}
+
+    R = Rxyz_mat(a, b, c)
+    @test R' ≈ inv(R)
+
+    Ri = Rxyz_inv_mat(a, b, c)
+    @test Ri' ≈ inv(Ri)
+
+    @test Ri ≈ inv(R)
+
+    R = Rxyz_mat(a, 0, 0)
+    @test R ≈ Rz(a)
+
+    R = Rxyz_mat(0, b, 0)
+    @test R ≈ Ry(b)
+
+    R = Rxyz_mat(0, 0, c)
+    @test R ≈ Rx(c)
+end

--- a/test/rotate3.jl
+++ b/test/rotate3.jl
@@ -51,4 +51,6 @@ end
 
     R = Rxyz_mat(0, 0, c)
     @test R ≈ Rx(c)
+
+    @test all((@inferred IP.Rxyz_inv((2, 1, 3), π/2, 0, 0)) .≈ (1,-2, 3))
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,6 +6,7 @@ using ImagePhantoms
 include("helper.jl")
 
 include("core.jl")
+include("rotate3.jl")
 
 include("shape2.jl")
 include("shepplogan.jl")

--- a/test/shape3.jl
+++ b/test/shape3.jl
@@ -59,17 +59,17 @@ end
 # constructors
 function test3_construct(Shape, shape)
     @test Shape <: AbstractShape{3}
-    @isob3 @inferred Object(Shape(), (1,2,3), (4,5,6), (π, π/4), 5.0f0)
-    @isob3 @inferred Object(Shape(), (1,2,3), (4,5,6), (0, 0), 5.0f0)
+    @isob3 @inferred Object(Shape(), (1,2,3), (4,5,6), (π, π/4, 0), 5.0f0)
+    @isob3 @inferred Object(Shape(), (1,2,3), (4,5,6), (0, 0, 0), 5.0f0)
     @isob3 @inferred Object(Shape(), center=(1,2,3))
-    @isob3 @inferred shape((1,2.,3), (4,5//1,6), (π, π/4), 5.0f0)
-    @isob3 @inferred shape(1, 2., 3, 4//1, 5, 6., π, π/4, 5.0f0)
+    @isob3 @inferred shape((1,2.,3), (4,5//1,6), (π, π/4, 0), 5.0f0)
+    @isob3 @inferred shape(1, 2., 3, 4//1, 5, 6., π, π/4, 0, 5.0f0)
 end
 
 
 # basic methods
 function test3_op(Shape, shape)
-    ob = @inferred shape((1,2.,3), (4,5//1,6), (π, π/4), 5.0f0)
+    ob = @inferred shape((1,2.,3), (4,5//1,6), (π, π/4, 0), 5.0f0)
 
     @isob3 @inferred IP.rotate(ob, π)
 
@@ -124,7 +124,7 @@ for (Shape, shape, lmax, lmax1, tol1, tolk, tolp) in list
     y = LinRange(-1,1,12)*5
     z = LinRange(-1,1,11)*5
 
-    ob = @inferred shape((1, 2., 3), (4//1, 5, 6), (π/6, 0), 5.0f0)
+    ob = @inferred shape((1, 2., 3), (4//1, 5, 6), (π/6, 0, 0), 5.0f0)
 
     show(devnull, ob)
     @test (@inferred eltype(ob)) == Float32
@@ -171,7 +171,7 @@ for (Shape, shape, lmax, lmax1, tol1, tolk, tolp) in list
             width = (30m, 40m, 50m)
             center = (8m, 7m, 6m)
             ϕ = π/6
-            ob = shape(center, width, (ϕ, 0), 1.0f0)
+            ob = shape(center, width, (ϕ, 0, 0), 1.0f0)
             @inferred IP._radon(ob, 0m, (1//2)m, 3f0, 4.)
             x1 = radon([center[1]], [center[3]], [0], [0], [ob])[1]
             x2 = radon([center[1]], [center[3]], 0, 0, [ob])[1]
@@ -186,7 +186,7 @@ for (Shape, shape, lmax, lmax1, tol1, tolk, tolp) in list
     (L,M,N) = (2^7,2^7+2,2^7+3) # odd
     ig = ImageGeom( dims=(L,M,N), deltas=(1.0m, 1.1m, 1.2m), offsets=:dsp)
     width = (30m, 40m, 50m)
-    ob = shape((8m, 7m, 6m), width, (π/6, 0), 5.0f0)
+    ob = shape((8m, 7m, 6m), width, (π/6, 0, 0), 5.0f0)
     volume = IP.volume(ob)
     zscale = 1 / (ob.value * volume) # normalize spectra
 
@@ -211,7 +211,7 @@ for (Shape, shape, lmax, lmax1, tol1, tolk, tolp) in list
   @testset "proj-slice" begin # Fourier-slice theorem
     center = (20mm, 10mm, 5mm)
     width = (25mm, 35mm, 15mm)
-    angles = (π/6, 0)
+    angles = (π/6, 0, 0)
     ob = shape(center, width, angles, 1.0f0)
 
     pg = ImageGeom((2^8,2^7), (0.6mm,1.0mm), (0.5,0.5)) # projection sampling

--- a/test/shape3.jl
+++ b/test/shape3.jl
@@ -87,7 +87,7 @@ end
 
 function test3_radon(Shape, shape, ob)
     @inferred IP.xray1(Shape(), 0.5f0, 0.3, π/6, π/5)
-    @inferred IP._xray(Shape(), (0., 0., 0.), (2,2,2), (π/3,0), 0.5f0, 0.3, π/6, π/5)
+    @inferred IP._xray(Shape(), (0., 0., 0.), (2,2,2), (π/3,0,0), 0.5f0, 0.3, π/6, π/5)
 
     @test (@inferred IP.xray1(Shape(), 0, 0, 0, 0)) > 0
     @test (@inferred IP.xray1(Shape(), 0f0, 0., 0, 0)) > 0


### PR DESCRIPTION
This is more a request for comments pull request. I figured in #56 that the third rotation angle in 3D is currently missing. This PR introduces it but I am not sure if the missing third angle was on purpose. I understand that it would not matter for symmetric objects like the ellipsoid, but if I see it right for the cuboid, the third angle does matter.

Unit tests are passing but this needs to be carefully reviewed since I basically just tried to get the test working and had no look at other things like the documentation.