### PR TITLE
Fix non-positive width

### DIFF
--- a/docs/lit/examples/09-disk.jl
+++ b/docs/lit/examples/09-disk.jl
@@ -16,6 +16,7 @@ using ImagePhantoms: ellipse, phantom, disk_phantom_params
 using ImageGeoms: ImageGeom
 using MIRTjim: jim, prompt
 using Plots # @animate, gif
+using Random: seed!
 
 # The following line is helpful when running this file as a script;
 # this way it will prompt user to hit a key after each figure is displayed.
@@ -49,6 +50,7 @@ function disk_phantom(title::String)
     img = phantom(x, y, objects, oversample)
     jim(x, y, img; title, clim=(0,1300))
 end
+seed!(0)
 disk_phantom("A single disk phantom realization")
 
 

--- a/src/object.jl
+++ b/src/object.jl
@@ -67,8 +67,8 @@ struct Object{S, D, V, C, A, Da, T} <: AbstractObject
             throw(ArgumentError("D=$D vs ndims(S)=$(ndims(S)) for S=$S"))
         D == 2 == Da + 1 || D == Da == 3 ||
             throw(ArgumentError("Da=$Da does not fit to D=$D"))
-        all(width .> zero(eltype(width))) ||
-            throw(ArgumentError("widths must be positive"))
+        all(>(zero(eltype(width))), width) ||
+            throw(ArgumentError("width $(minimum(width)) not positive"))
 
         C = promote_type(eltype.(center)..., eltype.(width)...)
         angle = promote((1f0 .* angle)...) # ensure at least Float32


### PR DESCRIPTION
A previous build of Docs had a perplexing non-positive ellipse width in 09-disk.jl example,
after the otherwise benign update to actions/checkout v5
Setting seed and reporting minimum width if non-positive should help identify the issue.